### PR TITLE
feat(model): Add properties for units and tolerance

### DIFF
--- a/honeybee_schema/bc.py
+++ b/honeybee_schema/bc.py
@@ -19,13 +19,21 @@ class Outdoors(BaseModel):
         description='A boolean noting whether the boundary is exposed to wind.'
     )
 
-    view_factor: Union[float, Autocalculate] = Field(
+    view_factor: Union[Autocalculate, float] = Field(
         Autocalculate(),
         ge=0,
         le=1,
         description='A number for the view factor to the ground. This can also be '
             'an Autocalculate object to have the view factor automatically calculated.'
     )
+
+    class Config:
+        @staticmethod
+        def schema_extra(schema, model):
+            schema['properties']['view_factor']['anyOf'] = [
+                    {"$ref": "#/components/schemas/Autocalculate"},
+                    {"type": "number", "minimum": 0, "maximum": 1}
+                ]
 
 class Surface(BaseModel):
 

--- a/honeybee_schema/energy/hvac.py
+++ b/honeybee_schema/energy/hvac.py
@@ -63,7 +63,7 @@ class IdealAirSystemAbridged(NamedEnergyBaseModel):
         description='A number for the minimum cooling supply air temperature [C].'
     )
 
-    heating_limit: Union[float, Autosize, NoLimit] = Field(
+    heating_limit: Union[Autosize, NoLimit, float] = Field(
         Autosize(),
         ge=0,
         description='A number for the maximum heating capacity in Watts. This '
@@ -72,7 +72,7 @@ class IdealAirSystemAbridged(NamedEnergyBaseModel):
             'be a NoLimit boject to indicate no upper limit to the heating capacity.'
     )
 
-    cooling_limit: Union[float, Autosize, NoLimit] = Field(
+    cooling_limit: Union[Autosize, NoLimit, float] = Field(
         Autosize(),
         ge=0,
         description='A number for the maximum cooling capacity in Watts. This '
@@ -105,6 +105,20 @@ class IdealAirSystemAbridged(NamedEnergyBaseModel):
         assert heat_temp > cool_temp, 'IdealAirSystem heating_air_temperature must be ' \
             'greater than cooling_air_temperature.'
         return values
+
+    class Config:
+        @staticmethod
+        def schema_extra(schema, model):
+            schema['properties']['heating_limit']['anyOf'] = [
+                    {"$ref": "#/components/schemas/NoLimit"},
+                    {"$ref": "#/components/schemas/Autosize"},
+                    {"type": "number", "minimum": 0}
+                ]
+            schema['properties']['cooling_limit']['anyOf'] = [
+                    {"$ref": "#/components/schemas/NoLimit"},
+                    {"$ref": "#/components/schemas/Autosize"},
+                    {"type": "number", "minimum": 0}
+                ]
 
 
 if __name__ == '__main__':

--- a/honeybee_schema/energy/load.py
+++ b/honeybee_schema/energy/load.py
@@ -44,7 +44,7 @@ class PeopleAbridged(NamedEnergyBaseModel):
         'value is 0.30.'
     )
 
-    latent_fraction: Union[float, Autocalculate] = Field(
+    latent_fraction: Union[Autocalculate, float] = Field(
         Autocalculate(),
         ge=0,
         le=1,
@@ -61,6 +61,14 @@ class PeopleAbridged(NamedEnergyBaseModel):
             assert rad + latent <= 1, \
                 'Sum of radiant and latent fractions cannot be greater than 1.'
         return values
+
+    class Config:
+        @staticmethod
+        def schema_extra(schema, model):
+            schema['properties']['latent_fraction']['anyOf'] = [
+                    {"$ref": "#/components/schemas/Autocalculate"},
+                    {"type": "number", "minimum": 0, "maximum": 1}
+                ]
 
 
 class LightingAbridged(NamedEnergyBaseModel):

--- a/honeybee_schema/energy/schedule.py
+++ b/honeybee_schema/energy/schedule.py
@@ -36,12 +36,12 @@ class ScheduleTypeLimit(NamedEnergyBaseModel):
 
     type: constr(regex='^ScheduleTypeLimit$') = 'ScheduleTypeLimit'
 
-    lower_limit: Union[float, NoLimit] = Field(
+    lower_limit: Union[NoLimit, float] = Field(
         default=NoLimit(),
         description='Lower limit for the schedule type or NoLimit.'
     )
 
-    upper_limit: Union[float, NoLimit] = Field(
+    upper_limit: Union[NoLimit, float] = Field(
         default=NoLimit(),
         description='Upper limit for the schedule type or NoLimit.'
     )
@@ -49,6 +49,18 @@ class ScheduleTypeLimit(NamedEnergyBaseModel):
     numeric_type: ScheduleNumericType = ScheduleNumericType.continuous
 
     unit_type: ScheduleUnitType = ScheduleUnitType.dimensionless
+
+    class Config:
+        @staticmethod
+        def schema_extra(schema, model):
+            schema['properties']['lower_limit']['anyOf'] = [
+                    {"$ref": "#/components/schemas/NoLimit"},
+                    {"type": "number"}
+                ]
+            schema['properties']['upper_limit']['anyOf'] = [
+                    {"$ref": "#/components/schemas/NoLimit"},
+                    {"type": "number"}
+                ]
 
 
 class ScheduleDay(NamedEnergyBaseModel):

--- a/honeybee_schema/model.py
+++ b/honeybee_schema/model.py
@@ -315,6 +315,14 @@ class Room(NamedBaseModel):
     )
 
 
+class UnitsSystems(str, Enum):
+    meters = 'Meters'
+    millimeters = 'Millimeters'
+    feet = 'Feet'
+    inches = 'Inches'
+    centimeters = 'Centimeters'
+
+
 class ModelProperties(BaseModel):
 
     type: constr(regex='^ModelProperties$') = 'ModelProperties'
@@ -364,6 +372,40 @@ class Model(NamedBaseModel):
         ge=0,
         lt=360,
         description='The clockwise north direction in degrees.'
+    )
+
+    units_system: UnitsSystems = Field(
+        default=UnitsSystems.meters,
+        description='Text for the units system in which the model geometry exists. '
+            'This is used to scale the geometry to the correct units for simulation '
+            'engines like EnergyPlus, which requires all geometry be in meters.'
+    )
+
+    tolerance: float = Field(
+        default=-1,
+        description='The maximum difference between x, y, and z values at which '
+            'vertices are considered equivalent. This value should be in the Model '
+            'units_system and is used in a variety of checks, including checks for '
+            'whether Room faces form a closed volume and subsequently correcting all '
+            'face normals point outward from the Room. Any negative values will result '
+            'in no attempt to evaluate whether the Room volumes is closed or check '
+            'face direction. So it is recommended that this always be a positive '
+            'number when such checks have not been performed on a given Model. '
+            'Typical tolerances for builing geometry range from 0.1 to 0.0001 '
+            'depending on the units system.'
+    )
+
+    angle_tolerance: float = Field(
+        default=-1,
+        description='The max angle difference in degrees that vertices are '
+            'allowed to differ from one another in order to consider them colinear. '
+            'This value is used in a variety of checks, including checks for '
+            'whether Room faces form a closed volume and subsequently correcting all '
+            'face normals point outward from the Room. Any negative values will result '
+            'in no attempt to evaluate whether the Room volumes is closed or check '
+            'face direction. So it is recommended that this always be a positive '
+            'number when such checks have not been performed on a given Model. '
+            'Typical tolerances for builing geometry are often around 1 degree.'
     )
 
     properties: ModelProperties = Field(

--- a/honeybee_schema/model.py
+++ b/honeybee_schema/model.py
@@ -315,7 +315,7 @@ class Room(NamedBaseModel):
     )
 
 
-class UnitsSystems(str, Enum):
+class Units(str, Enum):
     meters = 'Meters'
     millimeters = 'Millimeters'
     feet = 'Feet'
@@ -374,34 +374,34 @@ class Model(NamedBaseModel):
         description='The clockwise north direction in degrees.'
     )
 
-    units_system: UnitsSystems = Field(
-        default=UnitsSystems.meters,
-        description='Text for the units system in which the model geometry exists. '
+    units: Units = Field(
+        default=Units.meters,
+        description='Text indicating the units in which the model geometry exists. '
             'This is used to scale the geometry to the correct units for simulation '
             'engines like EnergyPlus, which requires all geometry be in meters.'
     )
 
     tolerance: float = Field(
-        default=-1,
+        default=0,
         description='The maximum difference between x, y, and z values at which '
             'vertices are considered equivalent. This value should be in the Model '
-            'units_system and is used in a variety of checks, including checks for '
+            'units and it is used in a variety of checks, including checks for '
             'whether Room faces form a closed volume and subsequently correcting all '
-            'face normals point outward from the Room. Any negative values will result '
-            'in no attempt to evaluate whether the Room volumes is closed or check '
+            'face normals point outward from the Room. A value of 0 will result '
+            'in no attempt to evaluate whether Room volumes are closed or check '
             'face direction. So it is recommended that this always be a positive '
-            'number when such checks have not been performed on a given Model. '
+            'number when such checks have not been performed on a Model. '
             'Typical tolerances for builing geometry range from 0.1 to 0.0001 '
-            'depending on the units system.'
+            'depending on the units of the geometry.'
     )
 
     angle_tolerance: float = Field(
-        default=-1,
+        default=0,
         description='The max angle difference in degrees that vertices are '
             'allowed to differ from one another in order to consider them colinear. '
             'This value is used in a variety of checks, including checks for '
             'whether Room faces form a closed volume and subsequently correcting all '
-            'face normals point outward from the Room. Any negative values will result '
+            'face normals point outward from the Room. A value of 0 will result '
             'in no attempt to evaluate whether the Room volumes is closed or check '
             'face direction. So it is recommended that this always be a positive '
             'number when such checks have not been performed on a given Model. '

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ setuptools.setup(
     long_description=long_description,
     long_description_content_type="text/markdown",
     url="https://github.com/ladybug-tools-in2/honeybee-schema",
-    packages=setuptools.find_packages(exclude=["tests"]),
+    packages=setuptools.find_packages(exclude=["tests", "scripts", "samples"]),
     install_requires=requirements,
     classifiers=[
         "Programming Language :: Python :: 3.6",


### PR DESCRIPTION
This commit allows schema users to store the units system and tolerance with their Model JSONs. The aim of this is that, by specifying these values, schema users don't need to worry about tedious geometry checks like whether all faces point outwards from a Room. This also means that they can build the Models in the units systems that they want and our core libraries will take care of any geometry scaling needed before the export to simulation engines. This should be a relief to Konrad who has to deal with Revit using feet as its native units system.

@mostapharoudsari , the only case that worried me a bit about storing tolerance and units systems on the Model is that I know you have a whole separate schema for point grids and this makes me wonder if the units system should be specified "one level higher" above both the Model and the point grids. But, given that Radiance doesn't expect the geometry to be in a certain units system and we don;t need to scale the model to run it through Radiance, this might be extra complexity with no real benefit. Still, I wanted to check with you about this and make sure you don't see an issue.