### PR TITLE
fix(ci): Use Python 3.7 for docs generation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: python
 
 python:
-  - "3.6"
+  - "3.7"
 
 jobs:
   include:
@@ -31,6 +31,7 @@ jobs:
   - stage: docs
     if: branch = master AND (NOT type IN (pull_request))
     script:
+    - pip install -U .
     - python ./docs.py
     deploy:
       provider: pages


### PR DESCRIPTION
I think pydantic might not be working correctly in Python 3.6