### PR TITLE
fix(constructionset): Differentiate sub-set class names from radiance

### DIFF
--- a/honeybee_schema/energy/constructionset.py
+++ b/honeybee_schema/energy/constructionset.py
@@ -12,6 +12,7 @@ from .material import EnergyMaterial, EnergyMaterialNoMass, \
     EnergyWindowMaterialGasMixture, EnergyWindowMaterialSimpleGlazSys, \
     EnergyWindowMaterialBlind, EnergyWindowMaterialGlazing, EnergyWindowMaterialShade
 
+
 class _FaceSubSetAbridged(NoExtraBaseModel):
     """A set of constructions for wall, floor, or roof assemblies."""
 
@@ -40,22 +41,25 @@ class _FaceSubSetAbridged(NoExtraBaseModel):
     )
 
 
-class WallSetAbridged(_FaceSubSetAbridged):
+class WallConstructionSetAbridged(_FaceSubSetAbridged):
     """A set of constructions for wall assemblies."""
 
-    type: constr(regex='^WallSetAbridged$') = 'WallSetAbridged'
+    type: constr(regex='^WallConstructionSetAbridged$') = \
+        'WallConstructionSetAbridged'
 
 
-class FloorSetAbridged(_FaceSubSetAbridged):
+class FloorConstructionSetAbridged(_FaceSubSetAbridged):
     """A set of constructions for floor assemblies."""
 
-    type: constr(regex='^FloorSetAbridged$') = 'FloorSetAbridged'
+    type: constr(regex='^FloorConstructionSetAbridged$') = \
+        'FloorConstructionSetAbridged'
 
 
-class RoofCeilingSetAbridged(_FaceSubSetAbridged):
+class RoofCeilingConstructionSetAbridged(_FaceSubSetAbridged):
     """A set of constructions for roof and ceiling assemblies."""
 
-    type: constr(regex='^RoofCeilingSetAbridged$') = 'RoofCeilingSetAbridged'
+    type: constr(regex='^RoofCeilingConstructionSetAbridged$') = \
+        'RoofCeilingConstructionSetAbridged'
 
 
 class _FaceSubSet(NoExtraBaseModel):
@@ -80,28 +84,29 @@ class _FaceSubSet(NoExtraBaseModel):
     )
 
 
-class WallSet(_FaceSubSet):
+class WallConstructionSet(_FaceSubSet):
     """A set of constructions for wall assemblies."""
 
-    type: constr(regex='^WallSet$') = 'WallSet'
+    type: constr(regex='^WallConstructionSet$') = 'WallConstructionSet'
 
 
-class FloorSet(_FaceSubSet):
+class FloorConstructionSet(_FaceSubSet):
     """A set of constructions for floor assemblies."""
 
-    type: constr(regex='^FloorSet$') = 'FloorSet'
+    type: constr(regex='^FloorConstructionSet$') = 'FloorConstructionSet'
 
 
-class RoofCeilingSet(_FaceSubSet):
+class RoofCeilingConstructionSet(_FaceSubSet):
     """A set of constructions for roof and ceiling assemblies."""
 
-    type: constr(regex='^RoofCeilingSet$') = 'RoofCeilingSet'
+    type: constr(regex='^RoofCeilingConstructionSet$') = 'RoofCeilingConstructionSet'
 
 
-class ApertureSetAbridged(NoExtraBaseModel):
+class ApertureConstructionSetAbridged(NoExtraBaseModel):
     """A set of constructions for aperture assemblies."""
 
-    type: constr(regex='^ApertureSetAbridged$') = 'ApertureSetAbridged'
+    type: constr(regex='^ApertureConstructionSetAbridged$') = \
+        'ApertureConstructionSetAbridged'
 
     interior_construction: str = Field(
         default=None,
@@ -138,10 +143,10 @@ class ApertureSetAbridged(NoExtraBaseModel):
     )
 
 
-class ApertureSet(NoExtraBaseModel):
+class ApertureConstructionSet(NoExtraBaseModel):
     """A set of constructions for aperture assemblies."""
 
-    type: constr(regex='^ApertureSet$') = 'ApertureSet'
+    type: constr(regex='^ApertureConstructionSet$') = 'ApertureConstructionSet'
 
     interior_construction: WindowConstruction = Field(
         default=None,
@@ -170,10 +175,10 @@ class ApertureSet(NoExtraBaseModel):
     )
 
 
-class DoorSetAbridged(NoExtraBaseModel):
+class DoorConstructionSetAbridged(NoExtraBaseModel):
     """A set of constructions for door assemblies."""
 
-    type: constr(regex='^DoorSetAbridged$') = 'DoorSetAbridged'
+    type: constr(regex='^DoorConstructionSetAbridged$') = 'DoorConstructionSetAbridged'
 
     interior_construction: str = Field(
         default=None,
@@ -217,10 +222,10 @@ class DoorSetAbridged(NoExtraBaseModel):
     )
 
 
-class DoorSet(NoExtraBaseModel):
+class DoorConstructionSet(NoExtraBaseModel):
     """A set of constructions for door assemblies."""
 
-    type: constr(regex='^DoorSet$') = 'DoorSet'
+    type: constr(regex='^DoorConstructionSet$') = 'DoorConstructionSet'
 
     interior_construction: OpaqueConstruction = Field(
         default=None,
@@ -259,29 +264,29 @@ class ConstructionSetAbridged(IDdEnergyBaseModel):
 
     type: constr(regex='^ConstructionSetAbridged$') = 'ConstructionSetAbridged'
 
-    wall_set: WallSetAbridged = Field(
+    wall_set: WallConstructionSetAbridged = Field(
         default=None,
-        description='A WallSetAbridged object for this ConstructionSet.'
+        description='A WallConstructionSetAbridged object for this ConstructionSet.'
     )
 
-    floor_set: FloorSetAbridged = Field(
+    floor_set: FloorConstructionSetAbridged = Field(
         default=None,
-        description='A FloorSetAbridged object for this ConstructionSet.'
+        description='A FloorConstructionSetAbridged object for this ConstructionSet.'
     )
 
-    roof_ceiling_set: RoofCeilingSetAbridged = Field(
+    roof_ceiling_set: RoofCeilingConstructionSetAbridged = Field(
         default=None,
-        description='A RoofCeilingSetAbridged object for this ConstructionSet.'
+        description='A RoofCeilingConstructionSetAbridged object for this ConstructionSet.'
     )
 
-    aperture_set: ApertureSetAbridged = Field(
+    aperture_set: ApertureConstructionSetAbridged = Field(
         default=None,
-        description='A ApertureSetAbridged object for this ConstructionSet.'
+        description='A ApertureConstructionSetAbridged object for this ConstructionSet.'
     )
 
-    door_set: DoorSetAbridged = Field(
+    door_set: DoorConstructionSetAbridged = Field(
         default=None,
-        description='A DoorSetAbridged object for this ConstructionSet.'
+        description='A DoorConstructionSetAbridged object for this ConstructionSet.'
     )
 
     shade_construction: str = Field(
@@ -307,29 +312,29 @@ class ConstructionSet(ConstructionSetAbridged):
 
     type: constr(regex='^ConstructionSet$') = 'ConstructionSet'
 
-    wall_set: WallSet = Field(
+    wall_set: WallConstructionSet = Field(
         default=None,
-        description='A WallSet object for this ConstructionSet.'
+        description='A WallConstructionSet object for this ConstructionSet.'
     )
 
-    floor_set: FloorSet = Field(
+    floor_set: FloorConstructionSet = Field(
         default=None,
-        description='A FloorSet object for this ConstructionSet.'
+        description='A FloorConstructionSet object for this ConstructionSet.'
     )
 
-    roof_ceiling_set: RoofCeilingSet = Field(
+    roof_ceiling_set: RoofCeilingConstructionSet = Field(
         default=None,
-        description='A RoofCeilingSet object for this ConstructionSet.'
+        description='A RoofCeilingConstructionSet object for this ConstructionSet.'
     )
 
-    aperture_set: ApertureSet = Field(
+    aperture_set: ApertureConstructionSet = Field(
         default=None,
-        description='A ApertureSet object for this ConstructionSet.'
+        description='A ApertureConstructionSet object for this ConstructionSet.'
     )
 
-    door_set: DoorSet = Field(
+    door_set: DoorConstructionSet = Field(
         default=None,
-        description='A DoorSet object for this ConstructionSet.'
+        description='A DoorConstructionSet object for this ConstructionSet.'
     )
 
     shade_construction: ShadeConstruction = Field(

--- a/honeybee_schema/energy/hvac.py
+++ b/honeybee_schema/energy/hvac.py
@@ -122,4 +122,4 @@ class IdealAirSystemAbridged(IDdEnergyBaseModel):
 
 
 if __name__ == '__main__':
-    print(IdealAirSystem.schema_json(indent=2))
+    print(IdealAirSystemAbridged.schema_json(indent=2))

--- a/honeybee_schema/energy/load.py
+++ b/honeybee_schema/energy/load.py
@@ -95,6 +95,10 @@ class People(PeopleAbridged):
     class Config:
         @staticmethod
         def schema_extra(schema, model):
+            schema['properties']['latent_fraction']['anyOf'] = [
+                    {"$ref": "#/components/schemas/Autocalculate"},
+                    {"type": "number", "minimum": 0, "maximum": 1}
+                ]
             schema['properties']['occupancy_schedule']['anyOf'] = [
                     {"$ref": "#/components/schemas/ScheduleRuleset"},
                     {"$ref": "#/components/schemas/ScheduleFixedInterval"}

--- a/samples/construction_set/constructionset_abridged_complete.json
+++ b/samples/construction_set/constructionset_abridged_complete.json
@@ -2,32 +2,32 @@
     "type": "ConstructionSetAbridged",
     "identifier": "Default Generic Construction Set",
     "wall_set": {
-        "type": "WallSetAbridged",
+        "type": "WallConstructionSetAbridged",
         "exterior_construction": "Generic Exterior Wall",
         "interior_construction": "Generic Interior Wall",
         "ground_construction": "Generic Underground Wall"
     },
     "floor_set": {
-        "type": "FloorSetAbridged",
+        "type": "FloorConstructionSetAbridged",
         "exterior_construction": "Generic Exposed Floor",
         "interior_construction": "Generic Interior Floor",
         "ground_construction": "Generic Ground Slab"
     },
     "roof_ceiling_set": {
-        "type": "RoofCeilingSetAbridged",
+        "type": "RoofCeilingConstructionSetAbridged",
         "exterior_construction": "Generic Roof",
         "interior_construction": "Generic Interior Ceiling",
         "ground_construction": "Generic Underground Roof"
     },
     "aperture_set": {
-        "type": "ApertureSetAbridged",
+        "type": "ApertureConstructionSetAbridged",
         "window_construction": "Generic Double Pane",
         "interior_construction": "Generic Single Pane",
         "skylight_construction": "Generic Double Pane",
         "operable_construction": "Generic Double Pane"
     },
     "door_set": {
-        "type": "DoorSetAbridged",
+        "type": "DoorConstructionSetAbridged",
         "exterior_construction": "Generic Exterior Door",
         "interior_construction": "Generic Interior Door",
         "exterior_glass_construction": "Generic Double Pane",

--- a/samples/construction_set/constructionset_abridged_partial_exterior.json
+++ b/samples/construction_set/constructionset_abridged_partial_exterior.json
@@ -2,32 +2,32 @@
     "type": "ConstructionSetAbridged",
     "identifier": "2013::ClimateZone5::SteelFramed",
     "wall_set": {
-        "type": "WallSetAbridged",
+        "type": "WallConstructionSetAbridged",
         "exterior_construction": "Typical Insulated Steel Framed Exterior Wall-R19",
         "interior_construction": null,
         "ground_construction": "Typical Insulated Basement Mass Wall-R8"
     },
     "floor_set": {
-        "type": "FloorSetAbridged",
+        "type": "FloorConstructionSetAbridged",
         "exterior_construction": "Typical Insulated Steel Framed Exterior Floor-R27",
         "interior_construction": null,
         "ground_construction": "Typical Insulated Carpeted 8in Slab Floor-R5"
     },
     "roof_ceiling_set": {
-        "type": "RoofCeilingSetAbridged",
+        "type": "RoofCeilingConstructionSetAbridged",
         "exterior_construction": "Typical IEAD Roof-R32",
         "interior_construction": null,
         "ground_construction": null
     },
     "aperture_set": {
-        "type": "ApertureSetAbridged",
+        "type": "ApertureConstructionSetAbridged",
         "window_construction": "U 0.48 SHGC 0.40 Dbl Ref-D Clr 6mm/13mm",
         "interior_construction": null,
         "skylight_construction": "Window_U_0.50_SHGC_0.40_Skylight_Frame_Width_0.430_in",
         "operable_construction": "U 0.48 SHGC 0.40 Dbl Ref-D Clr 6mm/13mm"
     },
     "door_set": {
-        "type": "DoorSetAbridged",
+        "type": "DoorConstructionSetAbridged",
         "exterior_construction": "Typical Insulated Metal Door-R2",
         "interior_construction": null,
         "exterior_glass_construction": "U 0.44 SHGC 0.26 Dbl Ref-B-H Clr 6mm/13mm Air",

--- a/samples/construction_set/constructionset_complete.json
+++ b/samples/construction_set/constructionset_complete.json
@@ -2,7 +2,7 @@
     "type": "ConstructionSet",
     "identifier": "Default Generic Construction Set",
     "wall_set": {
-        "type": "WallSet",
+        "type": "WallConstructionSet",
         "exterior_construction": {
             "type": "OpaqueConstruction",
             "identifier": "Generic Exterior Wall",
@@ -224,7 +224,7 @@
         }
     },
     "floor_set": {
-        "type": "FloorSet",
+        "type": "FloorConstructionSet",
         "exterior_construction": {
             "type": "OpaqueConstruction",
             "identifier": "Generic Exposed Floor",
@@ -407,7 +407,7 @@
         }
     },
     "roof_ceiling_set": {
-        "type": "RoofCeilingSet",
+        "type": "RoofCeilingConstructionSet",
         "exterior_construction": {
             "type": "OpaqueConstruction",
             "identifier": "Generic Roof",
@@ -629,7 +629,7 @@
         }
     },
     "aperture_set": {
-        "type": "ApertureSet",
+        "type": "ApertureConstructionSet",
         "window_construction": {
             "type": "WindowConstruction",
             "identifier": "Generic Double Pane",
@@ -811,7 +811,7 @@
         }
     },
     "door_set": {
-        "type": "DoorSet",
+        "type": "DoorConstructionSet",
         "exterior_construction": {
             "type": "OpaqueConstruction",
             "identifier": "Generic Exterior Door",

--- a/samples/construction_set/constructionset_partial_exterior.json
+++ b/samples/construction_set/constructionset_partial_exterior.json
@@ -2,7 +2,7 @@
     "type": "ConstructionSet",
     "identifier": "2013::ClimateZone5::SteelFramed",
     "wall_set": {
-        "type": "WallSet",
+        "type": "WallConstructionSet",
         "exterior_construction": {
             "type": "OpaqueConstruction",
             "identifier": "Typical Insulated Steel Framed Exterior Wall-R19",
@@ -82,7 +82,7 @@
         }
     },
     "floor_set": {
-        "type": "FloorSet",
+        "type": "FloorConstructionSet",
         "exterior_construction": {
             "type": "OpaqueConstruction",
             "identifier": "Typical Insulated Steel Framed Exterior Floor-R27",
@@ -182,7 +182,7 @@
         }
     },
     "roof_ceiling_set": {
-        "type": "RoofCeilingSet",
+        "type": "RoofCeilingConstructionSet",
         "exterior_construction": {
             "type": "OpaqueConstruction",
             "identifier": "Typical IEAD Roof-R32",
@@ -231,7 +231,7 @@
         "ground_construction": null
     },
     "aperture_set": {
-        "type": "ApertureSet",
+        "type": "ApertureConstructionSet",
         "window_construction": {
             "type": "WindowConstruction",
             "identifier": "U 0.48 SHGC 0.40 Dbl Ref-D Clr 6mm/13mm",
@@ -388,7 +388,7 @@
         }
     },
     "door_set": {
-        "type": "DoorSet",
+        "type": "DoorConstructionSet",
         "exterior_construction": {
             "type": "OpaqueConstruction",
             "identifier": "Typical Insulated Metal Door-R2",

--- a/samples/model/model_complete_multi_zone_office.json
+++ b/samples/model/model_complete_multi_zone_office.json
@@ -13,32 +13,32 @@
                     "type": "ConstructionSetAbridged",
                     "identifier": "Default Generic Construction Set",
                     "wall_set": {
-                        "type": "WallSetAbridged",
+                        "type": "WallConstructionSetAbridged",
                         "exterior_construction": "Generic Exterior Wall",
                         "interior_construction": "Generic Interior Wall",
                         "ground_construction": "Generic Underground Wall"
                     },
                     "floor_set": {
-                        "type": "FloorSetAbridged",
+                        "type": "FloorConstructionSetAbridged",
                         "exterior_construction": "Generic Exposed Floor",
                         "interior_construction": "Generic Interior Floor",
                         "ground_construction": "Generic Ground Slab"
                     },
                     "roof_ceiling_set": {
-                        "type": "RoofCeilingSetAbridged",
+                        "type": "RoofCeilingConstructionSetAbridged",
                         "exterior_construction": "Generic Roof",
                         "interior_construction": "Generic Interior Ceiling",
                         "ground_construction": "Generic Underground Roof"
                     },
                     "aperture_set": {
-                        "type": "ApertureSetAbridged",
+                        "type": "ApertureConstructionSetAbridged",
                         "window_construction": "Generic Double Pane",
                         "interior_construction": "Generic Single Pane",
                         "skylight_construction": "Generic Double Pane",
                         "operable_construction": "Generic Double Pane"
                     },
                     "door_set": {
-                        "type": "DoorSetAbridged",
+                        "type": "DoorConstructionSetAbridged",
                         "exterior_construction": "Generic Exterior Door",
                         "interior_construction": "Generic Interior Door",
                         "exterior_glass_construction": "Generic Double Pane",
@@ -52,32 +52,32 @@
                     "type": "ConstructionSetAbridged",
                     "identifier": "Attic Construction Set",
                     "wall_set": {
-                        "type": "WallSetAbridged",
+                        "type": "WallConstructionSetAbridged",
                         "exterior_construction": null,
                         "interior_construction": null,
                         "ground_construction": null
                     },
                     "floor_set": {
-                        "type": "FloorSetAbridged",
+                        "type": "FloorConstructionSetAbridged",
                         "exterior_construction": null,
                         "interior_construction": "Attic Floor Construction",
                         "ground_construction": null
                     },
                     "roof_ceiling_set": {
-                        "type": "RoofCeilingSetAbridged",
+                        "type": "RoofCeilingConstructionSetAbridged",
                         "exterior_construction": "Attic Roof Construction",
                         "interior_construction": null,
                         "ground_construction": null
                     },
                     "aperture_set": {
-                        "type": "ApertureSetAbridged",
+                        "type": "ApertureConstructionSetAbridged",
                         "window_construction": null,
                         "interior_construction": null,
                         "skylight_construction": null,
                         "operable_construction": null
                     },
                     "door_set": {
-                        "type": "DoorSetAbridged",
+                        "type": "DoorConstructionSetAbridged",
                         "exterior_construction": null,
                         "interior_construction": null,
                         "exterior_glass_construction": null,
@@ -1759,23 +1759,23 @@
                     "wall_set": {
                         "exterior_modifier": "generic_wall_0.50",
                         "interior_modifier": "generic_wall_0.50",
-                        "type": "WallSetAbridged"
+                        "type": "WallConstructionSetAbridged"
                     },
                     "floor_set": {
                         "exterior_modifier": "generic_floor_0.20",
                         "interior_modifier": "generic_floor_0.20",
-                        "type": "FloorSetAbridged"
+                        "type": "FloorConstructionSetAbridged"
                     },
                     "roof_ceiling_set": {
                         "exterior_modifier": "generic_ceiling_0.80",
                         "interior_modifier": "generic_ceiling_0.80",
-                        "type": "RoofCeilingSetAbridged"
+                        "type": "RoofCeilingConstructionSetAbridged"
                     },
                     "aperture_set": {
                         "skylight_modifier": "generic_exterior_window_vis_0.64",
                         "operable_modifier": "generic_exterior_window_vis_0.64",
                         "interior_modifier": "generic_interior_window_vis_0.88",
-                        "type": "ApertureSetAbridged",
+                        "type": "ApertureConstructionSetAbridged",
                         "window_modifier": "generic_exterior_window_vis_0.64"
                     },
                     "door_set": {
@@ -1784,7 +1784,7 @@
                         "interior_glass_modifier": "generic_interior_window_vis_0.88",
                         "interior_modifier": "generic_opaque_door_0.50",
                         "overhead_modifier": "generic_opaque_door_0.50",
-                        "type": "DoorSetAbridged"
+                        "type": "DoorConstructionSetAbridged"
                     },
                     "shade_set": {
                         "exterior_modifier": "generic_exterior_shade_0.35",

--- a/samples/model/model_complete_office_floor.json
+++ b/samples/model/model_complete_office_floor.json
@@ -13,32 +13,32 @@
                     "type": "ConstructionSetAbridged",
                     "identifier": "Default Generic Construction Set",
                     "wall_set": {
-                        "type": "WallSetAbridged",
+                        "type": "WallConstructionSetAbridged",
                         "exterior_construction": "Generic Exterior Wall",
                         "interior_construction": "Generic Interior Wall",
                         "ground_construction": "Generic Underground Wall"
                     },
                     "floor_set": {
-                        "type": "FloorSetAbridged",
+                        "type": "FloorConstructionSetAbridged",
                         "exterior_construction": "Generic Exposed Floor",
                         "interior_construction": "Generic Interior Floor",
                         "ground_construction": "Generic Ground Slab"
                     },
                     "roof_ceiling_set": {
-                        "type": "RoofCeilingSetAbridged",
+                        "type": "RoofCeilingConstructionSetAbridged",
                         "exterior_construction": "Generic Roof",
                         "interior_construction": "Generic Interior Ceiling",
                         "ground_construction": "Generic Underground Roof"
                     },
                     "aperture_set": {
-                        "type": "ApertureSetAbridged",
+                        "type": "ApertureConstructionSetAbridged",
                         "window_construction": "Generic Double Pane",
                         "interior_construction": "Generic Single Pane",
                         "skylight_construction": "Generic Double Pane",
                         "operable_construction": "Generic Double Pane"
                     },
                     "door_set": {
-                        "type": "DoorSetAbridged",
+                        "type": "DoorConstructionSetAbridged",
                         "exterior_construction": "Generic Exterior Door",
                         "interior_construction": "Generic Interior Door",
                         "exterior_glass_construction": "Generic Double Pane",
@@ -1722,23 +1722,23 @@
                     "wall_set": {
                         "exterior_modifier": "generic_wall_0.50",
                         "interior_modifier": "generic_wall_0.50",
-                        "type": "WallSetAbridged"
+                        "type": "WallConstructionSetAbridged"
                     },
                     "floor_set": {
                         "exterior_modifier": "generic_floor_0.20",
                         "interior_modifier": "generic_floor_0.20",
-                        "type": "FloorSetAbridged"
+                        "type": "FloorConstructionSetAbridged"
                     },
                     "roof_ceiling_set": {
                         "exterior_modifier": "generic_ceiling_0.80",
                         "interior_modifier": "generic_ceiling_0.80",
-                        "type": "RoofCeilingSetAbridged"
+                        "type": "RoofCeilingConstructionSetAbridged"
                     },
                     "aperture_set": {
                         "skylight_modifier": "generic_exterior_window_vis_0.64",
                         "operable_modifier": "generic_exterior_window_vis_0.64",
                         "interior_modifier": "generic_interior_window_vis_0.88",
-                        "type": "ApertureSetAbridged",
+                        "type": "ApertureConstructionSetAbridged",
                         "window_modifier": "generic_exterior_window_vis_0.64"
                     },
                     "door_set": {
@@ -1747,7 +1747,7 @@
                         "interior_glass_modifier": "generic_interior_window_vis_0.88",
                         "interior_modifier": "generic_opaque_door_0.50",
                         "overhead_modifier": "generic_opaque_door_0.50",
-                        "type": "DoorSetAbridged"
+                        "type": "DoorConstructionSetAbridged"
                     },
                     "shade_set": {
                         "exterior_modifier": "generic_exterior_shade_0.35",

--- a/samples/model/model_complete_patient_room.json
+++ b/samples/model/model_complete_patient_room.json
@@ -13,32 +13,32 @@
                     "type": "ConstructionSetAbridged",
                     "identifier": "Default Generic Construction Set",
                     "wall_set": {
-                        "type": "WallSetAbridged",
+                        "type": "WallConstructionSetAbridged",
                         "exterior_construction": "Generic Exterior Wall",
                         "interior_construction": "Generic Interior Wall",
                         "ground_construction": "Generic Underground Wall"
                     },
                     "floor_set": {
-                        "type": "FloorSetAbridged",
+                        "type": "FloorConstructionSetAbridged",
                         "exterior_construction": "Generic Exposed Floor",
                         "interior_construction": "Generic Interior Floor",
                         "ground_construction": "Generic Ground Slab"
                     },
                     "roof_ceiling_set": {
-                        "type": "RoofCeilingSetAbridged",
+                        "type": "RoofCeilingConstructionSetAbridged",
                         "exterior_construction": "Generic Roof",
                         "interior_construction": "Generic Interior Ceiling",
                         "ground_construction": "Generic Underground Roof"
                     },
                     "aperture_set": {
-                        "type": "ApertureSetAbridged",
+                        "type": "ApertureConstructionSetAbridged",
                         "window_construction": "Generic Double Pane",
                         "interior_construction": "Generic Single Pane",
                         "skylight_construction": "Generic Double Pane",
                         "operable_construction": "Generic Double Pane"
                     },
                     "door_set": {
-                        "type": "DoorSetAbridged",
+                        "type": "DoorConstructionSetAbridged",
                         "exterior_construction": "Generic Exterior Door",
                         "interior_construction": "Generic Interior Door",
                         "exterior_glass_construction": "Generic Double Pane",
@@ -1338,23 +1338,23 @@
                     "wall_set": {
                         "exterior_modifier": "generic_wall_0.50",
                         "interior_modifier": "generic_wall_0.50",
-                        "type": "WallSetAbridged"
+                        "type": "WallConstructionSetAbridged"
                     },
                     "floor_set": {
                         "exterior_modifier": "generic_floor_0.20",
                         "interior_modifier": "generic_floor_0.20",
-                        "type": "FloorSetAbridged"
+                        "type": "FloorConstructionSetAbridged"
                     },
                     "roof_ceiling_set": {
                         "exterior_modifier": "generic_ceiling_0.80",
                         "interior_modifier": "generic_ceiling_0.80",
-                        "type": "RoofCeilingSetAbridged"
+                        "type": "RoofCeilingConstructionSetAbridged"
                     },
                     "aperture_set": {
                         "skylight_modifier": "generic_exterior_window_vis_0.64",
                         "operable_modifier": "generic_exterior_window_vis_0.64",
                         "interior_modifier": "generic_interior_window_vis_0.88",
-                        "type": "ApertureSetAbridged",
+                        "type": "ApertureConstructionSetAbridged",
                         "window_modifier": "generic_exterior_window_vis_0.64"
                     },
                     "door_set": {
@@ -1363,7 +1363,7 @@
                         "interior_glass_modifier": "generic_interior_window_vis_0.88",
                         "interior_modifier": "generic_opaque_door_0.50",
                         "overhead_modifier": "generic_opaque_door_0.50",
-                        "type": "DoorSetAbridged"
+                        "type": "DoorConstructionSetAbridged"
                     },
                     "shade_set": {
                         "exterior_modifier": "generic_exterior_shade_0.35",

--- a/samples/model/model_complete_single_zone_office.json
+++ b/samples/model/model_complete_single_zone_office.json
@@ -13,32 +13,32 @@
                     "type": "ConstructionSetAbridged",
                     "identifier": "Default Generic Construction Set",
                     "wall_set": {
-                        "type": "WallSetAbridged",
+                        "type": "WallConstructionSetAbridged",
                         "exterior_construction": "Generic Exterior Wall",
                         "interior_construction": "Generic Interior Wall",
                         "ground_construction": "Generic Underground Wall"
                     },
                     "floor_set": {
-                        "type": "FloorSetAbridged",
+                        "type": "FloorConstructionSetAbridged",
                         "exterior_construction": "Generic Exposed Floor",
                         "interior_construction": "Generic Interior Floor",
                         "ground_construction": "Generic Ground Slab"
                     },
                     "roof_ceiling_set": {
-                        "type": "RoofCeilingSetAbridged",
+                        "type": "RoofCeilingConstructionSetAbridged",
                         "exterior_construction": "Generic Roof",
                         "interior_construction": "Generic Interior Ceiling",
                         "ground_construction": "Generic Underground Roof"
                     },
                     "aperture_set": {
-                        "type": "ApertureSetAbridged",
+                        "type": "ApertureConstructionSetAbridged",
                         "window_construction": "Generic Double Pane",
                         "interior_construction": "Generic Single Pane",
                         "skylight_construction": "Generic Double Pane",
                         "operable_construction": "Generic Double Pane"
                     },
                     "door_set": {
-                        "type": "DoorSetAbridged",
+                        "type": "DoorConstructionSetAbridged",
                         "exterior_construction": "Generic Exterior Door",
                         "interior_construction": "Generic Interior Door",
                         "exterior_glass_construction": "Generic Double Pane",
@@ -1718,23 +1718,23 @@
                     "wall_set": {
                         "exterior_modifier": "generic_wall_0.50",
                         "interior_modifier": "generic_wall_0.50",
-                        "type": "WallSetAbridged"
+                        "type": "WallConstructionSetAbridged"
                     },
                     "floor_set": {
                         "exterior_modifier": "generic_floor_0.20",
                         "interior_modifier": "generic_floor_0.20",
-                        "type": "FloorSetAbridged"
+                        "type": "FloorConstructionSetAbridged"
                     },
                     "roof_ceiling_set": {
                         "exterior_modifier": "generic_ceiling_0.80",
                         "interior_modifier": "generic_ceiling_0.80",
-                        "type": "RoofCeilingSetAbridged"
+                        "type": "RoofCeilingConstructionSetAbridged"
                     },
                     "aperture_set": {
                         "skylight_modifier": "generic_exterior_window_vis_0.64",
                         "operable_modifier": "generic_exterior_window_vis_0.64",
                         "interior_modifier": "generic_interior_window_vis_0.88",
-                        "type": "ApertureSetAbridged",
+                        "type": "ApertureConstructionSetAbridged",
                         "window_modifier": "generic_exterior_window_vis_0.64"
                     },
                     "door_set": {
@@ -1743,7 +1743,7 @@
                         "interior_glass_modifier": "generic_interior_window_vis_0.88",
                         "interior_modifier": "generic_opaque_door_0.50",
                         "overhead_modifier": "generic_opaque_door_0.50",
-                        "type": "DoorSetAbridged"
+                        "type": "DoorConstructionSetAbridged"
                     },
                     "shade_set": {
                         "exterior_modifier": "generic_exterior_shade_0.35",

--- a/samples/model/model_complete_user_data.json
+++ b/samples/model/model_complete_user_data.json
@@ -13,32 +13,32 @@
                     "type": "ConstructionSetAbridged",
                     "identifier": "Default Generic Construction Set",
                     "wall_set": {
-                        "type": "WallSetAbridged",
+                        "type": "WallConstructionSetAbridged",
                         "exterior_construction": "Generic Exterior Wall",
                         "interior_construction": "Generic Interior Wall",
                         "ground_construction": "Generic Underground Wall"
                     },
                     "floor_set": {
-                        "type": "FloorSetAbridged",
+                        "type": "FloorConstructionSetAbridged",
                         "exterior_construction": "Generic Exposed Floor",
                         "interior_construction": "Generic Interior Floor",
                         "ground_construction": "Generic Ground Slab"
                     },
                     "roof_ceiling_set": {
-                        "type": "RoofCeilingSetAbridged",
+                        "type": "RoofCeilingConstructionSetAbridged",
                         "exterior_construction": "Generic Roof",
                         "interior_construction": "Generic Interior Ceiling",
                         "ground_construction": "Generic Underground Roof"
                     },
                     "aperture_set": {
-                        "type": "ApertureSetAbridged",
+                        "type": "ApertureConstructionSetAbridged",
                         "window_construction": "Generic Double Pane",
                         "interior_construction": "Generic Single Pane",
                         "skylight_construction": "Generic Double Pane",
                         "operable_construction": "Generic Double Pane"
                     },
                     "door_set": {
-                        "type": "DoorSetAbridged",
+                        "type": "DoorConstructionSetAbridged",
                         "exterior_construction": "Generic Exterior Door",
                         "interior_construction": "Generic Interior Door",
                         "exterior_glass_construction": "Generic Double Pane",
@@ -1688,23 +1688,23 @@
                     "wall_set": {
                         "exterior_modifier": "generic_wall_0.50",
                         "interior_modifier": "generic_wall_0.50",
-                        "type": "WallSetAbridged"
+                        "type": "WallConstructionSetAbridged"
                     },
                     "floor_set": {
                         "exterior_modifier": "generic_floor_0.20",
                         "interior_modifier": "generic_floor_0.20",
-                        "type": "FloorSetAbridged"
+                        "type": "FloorConstructionSetAbridged"
                     },
                     "roof_ceiling_set": {
                         "exterior_modifier": "generic_ceiling_0.80",
                         "interior_modifier": "generic_ceiling_0.80",
-                        "type": "RoofCeilingSetAbridged"
+                        "type": "RoofCeilingConstructionSetAbridged"
                     },
                     "aperture_set": {
                         "skylight_modifier": "generic_exterior_window_vis_0.64",
                         "operable_modifier": "generic_exterior_window_vis_0.64",
                         "interior_modifier": "generic_interior_window_vis_0.88",
-                        "type": "ApertureSetAbridged",
+                        "type": "ApertureConstructionSetAbridged",
                         "window_modifier": "generic_exterior_window_vis_0.64"
                     },
                     "door_set": {
@@ -1713,7 +1713,7 @@
                         "interior_glass_modifier": "generic_interior_window_vis_0.88",
                         "interior_modifier": "generic_opaque_door_0.50",
                         "overhead_modifier": "generic_opaque_door_0.50",
-                        "type": "DoorSetAbridged"
+                        "type": "DoorConstructionSetAbridged"
                     },
                     "shade_set": {
                         "exterior_modifier": "generic_exterior_shade_0.35",

--- a/samples/model/model_energy_detailed_loads.json
+++ b/samples/model/model_energy_detailed_loads.json
@@ -13,32 +13,32 @@
                     "type": "ConstructionSetAbridged",
                     "identifier": "Default Generic Construction Set",
                     "wall_set": {
-                        "type": "WallSetAbridged",
+                        "type": "WallConstructionSetAbridged",
                         "exterior_construction": "Generic Exterior Wall",
                         "interior_construction": "Generic Interior Wall",
                         "ground_construction": "Generic Underground Wall"
                     },
                     "floor_set": {
-                        "type": "FloorSetAbridged",
+                        "type": "FloorConstructionSetAbridged",
                         "exterior_construction": "Generic Exposed Floor",
                         "interior_construction": "Generic Interior Floor",
                         "ground_construction": "Generic Ground Slab"
                     },
                     "roof_ceiling_set": {
-                        "type": "RoofCeilingSetAbridged",
+                        "type": "RoofCeilingConstructionSetAbridged",
                         "exterior_construction": "Generic Roof",
                         "interior_construction": "Generic Interior Ceiling",
                         "ground_construction": "Generic Underground Roof"
                     },
                     "aperture_set": {
-                        "type": "ApertureSetAbridged",
+                        "type": "ApertureConstructionSetAbridged",
                         "window_construction": "Generic Double Pane",
                         "interior_construction": "Generic Single Pane",
                         "skylight_construction": "Generic Double Pane",
                         "operable_construction": "Generic Double Pane"
                     },
                     "door_set": {
-                        "type": "DoorSetAbridged",
+                        "type": "DoorConstructionSetAbridged",
                         "exterior_construction": "Generic Exterior Door",
                         "interior_construction": "Generic Interior Door",
                         "exterior_glass_construction": "Generic Double Pane",

--- a/samples/model/model_energy_fixed_interval.json
+++ b/samples/model/model_energy_fixed_interval.json
@@ -13,32 +13,32 @@
                     "type": "ConstructionSetAbridged",
                     "identifier": "Default Generic Construction Set",
                     "wall_set": {
-                        "type": "WallSetAbridged",
+                        "type": "WallConstructionSetAbridged",
                         "exterior_construction": "Generic Exterior Wall",
                         "interior_construction": "Generic Interior Wall",
                         "ground_construction": "Generic Underground Wall"
                     },
                     "floor_set": {
-                        "type": "FloorSetAbridged",
+                        "type": "FloorConstructionSetAbridged",
                         "exterior_construction": "Generic Exposed Floor",
                         "interior_construction": "Generic Interior Floor",
                         "ground_construction": "Generic Ground Slab"
                     },
                     "roof_ceiling_set": {
-                        "type": "RoofCeilingSetAbridged",
+                        "type": "RoofCeilingConstructionSetAbridged",
                         "exterior_construction": "Generic Roof",
                         "interior_construction": "Generic Interior Ceiling",
                         "ground_construction": "Generic Underground Roof"
                     },
                     "aperture_set": {
-                        "type": "ApertureSetAbridged",
+                        "type": "ApertureConstructionSetAbridged",
                         "window_construction": "Generic Double Pane",
                         "interior_construction": "Generic Single Pane",
                         "skylight_construction": "Generic Double Pane",
                         "operable_construction": "Generic Double Pane"
                     },
                     "door_set": {
-                        "type": "DoorSetAbridged",
+                        "type": "DoorConstructionSetAbridged",
                         "exterior_construction": "Generic Exterior Door",
                         "interior_construction": "Generic Interior Door",
                         "exterior_glass_construction": "Generic Double Pane",

--- a/samples/model/model_energy_no_program.json
+++ b/samples/model/model_energy_no_program.json
@@ -13,32 +13,32 @@
                     "type": "ConstructionSetAbridged",
                     "identifier": "Default Generic Construction Set",
                     "wall_set": {
-                        "type": "WallSetAbridged",
+                        "type": "WallConstructionSetAbridged",
                         "exterior_construction": "Generic Exterior Wall",
                         "interior_construction": "Generic Interior Wall",
                         "ground_construction": "Generic Underground Wall"
                     },
                     "floor_set": {
-                        "type": "FloorSetAbridged",
+                        "type": "FloorConstructionSetAbridged",
                         "exterior_construction": "Generic Exposed Floor",
                         "interior_construction": "Generic Interior Floor",
                         "ground_construction": "Generic Ground Slab"
                     },
                     "roof_ceiling_set": {
-                        "type": "RoofCeilingSetAbridged",
+                        "type": "RoofCeilingConstructionSetAbridged",
                         "exterior_construction": "Generic Roof",
                         "interior_construction": "Generic Interior Ceiling",
                         "ground_construction": "Generic Underground Roof"
                     },
                     "aperture_set": {
-                        "type": "ApertureSetAbridged",
+                        "type": "ApertureConstructionSetAbridged",
                         "window_construction": "Generic Double Pane",
                         "interior_construction": "Generic Single Pane",
                         "skylight_construction": "Generic Double Pane",
                         "operable_construction": "Generic Double Pane"
                     },
                     "door_set": {
-                        "type": "DoorSetAbridged",
+                        "type": "DoorConstructionSetAbridged",
                         "exterior_construction": "Generic Exterior Door",
                         "interior_construction": "Generic Interior Door",
                         "exterior_glass_construction": "Generic Double Pane",

--- a/samples/model/model_energy_properties_office.json
+++ b/samples/model/model_energy_properties_office.json
@@ -6,32 +6,32 @@
             "type": "ConstructionSetAbridged",
             "identifier": "Default Generic Construction Set",
             "wall_set": {
-                "type": "WallSetAbridged",
+                "type": "WallConstructionSetAbridged",
                 "exterior_construction": "Generic Exterior Wall",
                 "interior_construction": "Generic Interior Wall",
                 "ground_construction": "Generic Underground Wall"
             },
             "floor_set": {
-                "type": "FloorSetAbridged",
+                "type": "FloorConstructionSetAbridged",
                 "exterior_construction": "Generic Exposed Floor",
                 "interior_construction": "Generic Interior Floor",
                 "ground_construction": "Generic Ground Slab"
             },
             "roof_ceiling_set": {
-                "type": "RoofCeilingSetAbridged",
+                "type": "RoofCeilingConstructionSetAbridged",
                 "exterior_construction": "Generic Roof",
                 "interior_construction": "Generic Interior Ceiling",
                 "ground_construction": "Generic Underground Roof"
             },
             "aperture_set": {
-                "type": "ApertureSetAbridged",
+                "type": "ApertureConstructionSetAbridged",
                 "window_construction": "Generic Double Pane",
                 "interior_construction": "Generic Single Pane",
                 "skylight_construction": "Generic Double Pane",
                 "operable_construction": "Generic Double Pane"
             },
             "door_set": {
-                "type": "DoorSetAbridged",
+                "type": "DoorConstructionSetAbridged",
                 "exterior_construction": "Generic Exterior Door",
                 "interior_construction": "Generic Interior Door",
                 "exterior_glass_construction": "Generic Double Pane",

--- a/samples/model/model_energy_shoe_box.json
+++ b/samples/model/model_energy_shoe_box.json
@@ -13,32 +13,32 @@
                     "type": "ConstructionSetAbridged",
                     "identifier": "Default Generic Construction Set",
                     "wall_set": {
-                        "type": "WallSetAbridged",
+                        "type": "WallConstructionSetAbridged",
                         "exterior_construction": "Generic Exterior Wall",
                         "interior_construction": "Generic Interior Wall",
                         "ground_construction": "Generic Underground Wall"
                     },
                     "floor_set": {
-                        "type": "FloorSetAbridged",
+                        "type": "FloorConstructionSetAbridged",
                         "exterior_construction": "Generic Exposed Floor",
                         "interior_construction": "Generic Interior Floor",
                         "ground_construction": "Generic Ground Slab"
                     },
                     "roof_ceiling_set": {
-                        "type": "RoofCeilingSetAbridged",
+                        "type": "RoofCeilingConstructionSetAbridged",
                         "exterior_construction": "Generic Roof",
                         "interior_construction": "Generic Interior Ceiling",
                         "ground_construction": "Generic Underground Roof"
                     },
                     "aperture_set": {
-                        "type": "ApertureSetAbridged",
+                        "type": "ApertureConstructionSetAbridged",
                         "window_construction": "Generic Double Pane",
                         "interior_construction": "Generic Single Pane",
                         "skylight_construction": "Generic Double Pane",
                         "operable_construction": "Generic Double Pane"
                     },
                     "door_set": {
-                        "type": "DoorSetAbridged",
+                        "type": "DoorConstructionSetAbridged",
                         "exterior_construction": "Generic Exterior Door",
                         "interior_construction": "Generic Interior Door",
                         "exterior_glass_construction": "Generic Double Pane",
@@ -52,32 +52,32 @@
                     "type": "ConstructionSetAbridged",
                     "identifier": "Shoe Box Construction Set",
                     "wall_set": {
-                        "type": "WallSetAbridged",
+                        "type": "WallConstructionSetAbridged",
                         "exterior_construction": "Generic Exterior Wall",
                         "interior_construction": "Generic Interior Wall",
                         "ground_construction": null
                     },
                     "floor_set": {
-                        "type": "FloorSetAbridged",
+                        "type": "FloorConstructionSetAbridged",
                         "exterior_construction": null,
                         "interior_construction": "Generic Interior Floor",
                         "ground_construction": null
                     },
                     "roof_ceiling_set": {
-                        "type": "RoofCeilingSetAbridged",
+                        "type": "RoofCeilingConstructionSetAbridged",
                         "exterior_construction": null,
                         "interior_construction": "Generic Interior Ceiling",
                         "ground_construction": null
                     },
                     "aperture_set": {
-                        "type": "ApertureSetAbridged",
+                        "type": "ApertureConstructionSetAbridged",
                         "window_construction": "Generic Double Pane",
                         "interior_construction": null,
                         "skylight_construction": null,
                         "operable_construction": null
                     },
                     "door_set": {
-                        "type": "DoorSetAbridged",
+                        "type": "DoorConstructionSetAbridged",
                         "exterior_construction": null,
                         "interior_construction": null,
                         "exterior_glass_construction": null,

--- a/tests/test_constructionset.py
+++ b/tests/test_constructionset.py
@@ -1,6 +1,6 @@
 from honeybee_schema.energy.constructionset import ConstructionSetAbridged, \
-    WallSetAbridged, RoofCeilingSetAbridged, FloorSetAbridged, ApertureSetAbridged, \
-    DoorSetAbridged, ConstructionSet
+    WallConstructionSetAbridged, RoofCeilingConstructionSetAbridged, FloorConstructionSetAbridged, ApertureConstructionSetAbridged, \
+    DoorConstructionSetAbridged, ConstructionSet
 import os
 
 # target folder where all of the samples live


### PR DESCRIPTION
This commit changes the class names of sub-sets (eg WallSet) to be specific for energy (eg. WallConstructionSet). This will ensure that the two schemas do not conflict in honeybee-schema.

It also includes a fix for removing an additional layer of AnyOf object hierarchy in the People objects.