### PR TITLE
fix(openapi): add format for array items

### DIFF
--- a/honeybee_schema/_openapi.py
+++ b/honeybee_schema/_openapi.py
@@ -122,7 +122,13 @@ def get_openapi(
                 properties[prop] = set_format(properties[prop])
             except KeyError:
                 # referenced object
-                continue
+                if 'anyOf' in properties[prop]:
+                    new_any_of = []
+                    for item in properties[prop]['anyOf']:
+                        new_any_of.append(set_format(item))
+                    properties[prop]['anyOf'] = new_any_of
+                else:
+                    continue
 
         # sort fields to keep required ones on top
         if 'required' in s:
@@ -162,7 +168,9 @@ def get_openapi(
 
 def set_format(p):
     """Set format for a property."""
-    if p['type'] == 'number' and 'format' not in p:
+    if '$ref' in p:
+        return p
+    elif p['type'] == 'number' and 'format' not in p:
         p['format'] = 'double'
     elif p['type'] == 'integer' and 'format' not in p:
         p['format'] = 'int32'

--- a/honeybee_schema/_openapi.py
+++ b/honeybee_schema/_openapi.py
@@ -117,12 +117,9 @@ def get_openapi(
             properties['type'] = typ
         # add format to numbers and integers
         # this is helpful for C# generators
-        for prop, value in properties.items():
+        for prop in properties:
             try:
-                if value['type'] == 'number' and 'format' not in value:
-                    properties[prop]['format'] = 'double'
-                elif value['type'] == 'integer' and 'format' not in value:
-                    properties[prop]['format'] = 'int32'
+                properties[prop] = set_format(properties[prop])
             except KeyError:
                 # referenced object
                 continue
@@ -161,6 +158,17 @@ def get_openapi(
     open_api['components']['schemas'] = schemas
 
     return open_api
+
+
+def set_format(p):
+    """Set format for a property."""
+    if p['type'] == 'number' and 'format' not in p:
+        p['format'] = 'double'
+    elif p['type'] == 'integer' and 'format' not in p:
+        p['format'] = 'int32'
+    elif p['type'] == 'array':
+        p['items'] = set_format(p['items'])
+    return p
 
 
 def get_model_mapper(model, stoppage=None, full=True):


### PR DESCRIPTION
resolves #86

Current implementation was missing the check for items in an array. Now it is fixed. The new set_format method supports setting up the format for arrays and nested arrays.
