### PR TITLE
ci(release event workflow): remove dragonfly-schema

### DIFF
--- a/.github/workflows/emit-release-event.yaml
+++ b/.github/workflows/emit-release-event.yaml
@@ -13,10 +13,9 @@ jobs:
       matrix:
         client_repo:
           - ladybug-tools/honeybee-schema-dotnet
-          - ladybug-tools/dragonfly-schema
-  
+
     steps:
-    - name: "send repo dispatch to apiary"
+    - name: "send repo dispatch to honeybee-schema-dotnet"
       env:
         RELEASE_TAG: ${{ github.event.release.tag_name }}
         DISPATCH_URL: https://api.github.com/repos/${{ matrix.client_repo }}/dispatches


### PR DESCRIPTION
dependbot takes care of sending a PR to dragonfly-schema