### PR TITLE
Fix documentation issue

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,5 +1,5 @@
-coverage==4.5.2
-coveralls==1.5.1
-pytest==4.1.0
-pytest-cov==2.6.1
-twine==1.13.0
+coverage==5.1
+coveralls==2.0.0
+pytest==5.4.1
+pytest-cov==2.8.1
+twine==3.1.1

--- a/honeybee_schema/radiance/modifier.py
+++ b/honeybee_schema/radiance/modifier.py
@@ -1,4 +1,4 @@
-"""Modfier Schema"""
+"""Modifier Schema"""
 from __future__ import annotations
 from pydantic import Field, constr, validator, root_validator
 from typing import List, Union, Optional
@@ -14,7 +14,15 @@ class Void(BaseModel):
 class ModifierBase(IDdRadianceBaseModel):
     """Base class for Radiance Modifiers"""
 
-    modifier: _REFERENCE_UNION_MODIFIERS = Field(
+    type: constr(regex='^ModifierBase$') = 'ModifierBase'
+
+
+class Mirror(ModifierBase):
+    """Radiance mirror material."""
+
+    type: constr(regex='^mirror$') = 'mirror'
+
+    modifier:  _REFERENCE_UNION_MODIFIERS = Field(
         default=None,
         description='Material modifier (default: Void).'
         )
@@ -26,12 +34,6 @@ class ModifierBase(IDdRadianceBaseModel):
                     'where the modifier is defined based on other modifiers '
                     '(default: []).'
         )
-
-
-class Mirror(ModifierBase):
-    """Radiance mirror material."""
-
-    type: constr(regex='^mirror$') = 'mirror'
 
     r_reflectance: float = Field(
         default=1,
@@ -72,6 +74,19 @@ class Plastic(ModifierBase):
     """Radiance plastic material."""
 
     type: constr(regex='^plastic$') = 'plastic'
+
+    modifier:  _REFERENCE_UNION_MODIFIERS = Field(
+        default=None,
+        description='Material modifier (default: Void).'
+        )
+
+    dependencies: List[_REFERENCE_UNION_MODIFIERS] = Field(
+        default=[],
+        description='List of modifiers that this modifier depends on. '
+                    'This argument is only useful for defining advanced modifiers '
+                    'where the modifier is defined based on other modifiers '
+                    '(default: []).'
+        )
 
     r_reflectance: float = Field(
         default=0.0,
@@ -158,6 +173,19 @@ class Glass(ModifierBase):
 
     type: constr(regex='^glass$') = 'glass'
 
+    modifier:  _REFERENCE_UNION_MODIFIERS = Field(
+        default=None,
+        description='Material modifier (default: Void).'
+        )
+
+    dependencies: List[_REFERENCE_UNION_MODIFIERS] = Field(
+        default=[],
+        description='List of modifiers that this modifier depends on. '
+                    'This argument is only useful for defining advanced modifiers '
+                    'where the modifier is defined based on other modifiers '
+                    '(default: []).'
+        )
+
     r_transmissivity: float = Field(
         default=0.0,
         ge=0,
@@ -194,6 +222,19 @@ class BSDF(ModifierBase):
     """Radiance BSDF (Bidirectional Scattering Distribution Function) material."""
 
     type: constr(regex='^BSDF$') = 'BSDF'
+
+    modifier:  _REFERENCE_UNION_MODIFIERS = Field(
+        default=None,
+        description='Material modifier (default: Void).'
+        )
+
+    dependencies: List[_REFERENCE_UNION_MODIFIERS] = Field(
+        default=[],
+        description='List of modifiers that this modifier depends on. '
+                    'This argument is only useful for defining advanced modifiers '
+                    'where the modifier is defined based on other modifiers '
+                    '(default: []).'
+        )
 
     up_orientation: List[float] = Field(
         default=(0.01, 0.01, 1.00),
@@ -282,6 +323,19 @@ class Light(ModifierBase):
 
     type: constr(regex='^light$') = 'light'
 
+    modifier:  _REFERENCE_UNION_MODIFIERS = Field(
+        default=None,
+        description='Material modifier (default: Void).'
+        )
+
+    dependencies: List[_REFERENCE_UNION_MODIFIERS] = Field(
+        default=[],
+        description='List of modifiers that this modifier depends on. '
+                    'This argument is only useful for defining advanced modifiers '
+                    'where the modifier is defined based on other modifiers '
+                    '(default: []).'
+        )
+
     r_emittance: float = Field(
         default=0.0,
         ge=0,
@@ -320,9 +374,10 @@ class Glow(Light):
                     'to scene illumination.'
     )
 
-# Unioned Modifier Schema objects defined for type reference
-_REFERENCE_UNION_MODIFIERS = Union[Plastic, Glass, BSDF, Glow, Light, Trans, Void,
-                                   Mirror]
+
+# Union Modifier Schema objects defined for type reference
+_REFERENCE_UNION_MODIFIERS = \
+    Union[Plastic, Glass, BSDF, Glow, Light, Trans, Void, Mirror]
 
 # Required for self.referencing model
 # see https://pydantic-docs.helpmanual.io/#self-referencing-models
@@ -334,4 +389,3 @@ Glow.update_forward_refs()
 Light.update_forward_refs()
 Trans.update_forward_refs()
 Void.update_forward_refs()
-

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,1 @@
-pydantic==1.4
-pytest~=4.4.0
+git+https://github.com/samuelcolvin/pydantic.git@5067508eca6222b9315b1e38a30ddc975dee05e7

--- a/tests/test_openapi_docs.py
+++ b/tests/test_openapi_docs.py
@@ -6,5 +6,5 @@ os.chdir(root)
 
 
 def test_gen_openapi():
-    rc = os.system('python ./docs.py')
+    rc = os.system('python ./docs.py --version 0.0.1')
     assert rc == 0

--- a/tests/test_openapi_docs.py
+++ b/tests/test_openapi_docs.py
@@ -1,0 +1,10 @@
+"""Test generating OpenAPI docs."""
+import os
+
+root = os.path.dirname(os.path.dirname(__file__))
+os.chdir(root)
+
+
+def test_gen_openapi():
+    rc = os.system('python ./docs.py')
+    assert rc == 0


### PR DESCRIPTION
This is a change merely to fix the issue for generating the OpenAPI docs with inheritance. From Pydantic point of view the code is good as is but it's not the case for generating the schema with inheritance.

For some mysterious reason the `update_forward_ref` for `_REFERENCE_UNION_MODIFIERS` doesn't get triggered in `ModifierBase` class when creating the subclasses. Moving the fields that are dependent on `_REFERENCE_UNION_MODIFIERS` to the subclasses resolves the issue.

I know that this is adding some code duplication but it fixes the documentation issue for now. I'm willing to spend more time in the near future to find a better fix.

resolves #102

The test for docs will fail with the current bug in Pydantic but as mentioned in #102 it will work fine once the fix for OpenAPI documentation is merged.

@MingboPeng, here are the updated docs file with Radiance objects added to the model. Let me know you see any upcoming issues:

[openapi_docs.zip](https://github.com/ladybug-tools/honeybee-schema/files/4535846/openapi_docs.zip)
