### PR TITLE
fix(solar): Change default solar distribution to FullExteriorWithReflect

### DIFF
--- a/honeybee_schema/energy/simulation.py
+++ b/honeybee_schema/energy/simulation.py
@@ -99,7 +99,7 @@ class ShadowCalculation(NoExtraBaseModel):
     type: constr(regex='^ShadowCalculation$') = 'ShadowCalculation'
 
     solar_distribution: SolarDistribution = \
-        SolarDistribution.full_interior_and_exterior_with_reflections
+        SolarDistribution.full_exterior_with_reflection
 
     calculation_frequency: int = Field(
         30,

--- a/samples/model/model_5vertex_sub_faces_interior.json
+++ b/samples/model/model_5vertex_sub_faces_interior.json
@@ -1,0 +1,1373 @@
+{
+    "type": "Model",
+    "identifier": "TinyHouse",
+    "display_name": "TinyHouse",
+    "units": "Meters",
+    "properties": {
+        "type": "ModelProperties",
+        "energy": {
+            "type": "ModelEnergyProperties",
+            "terrain_type": "City",
+            "construction_sets": [
+                {
+                    "type": "ConstructionSetAbridged",
+                    "identifier": "Default Generic Construction Set",
+                    "wall_set": {
+                        "type": "WallConstructionSetAbridged",
+                        "exterior_construction": "Generic Exterior Wall",
+                        "interior_construction": "Generic Interior Wall",
+                        "ground_construction": "Generic Underground Wall"
+                    },
+                    "floor_set": {
+                        "type": "FloorConstructionSetAbridged",
+                        "exterior_construction": "Generic Exposed Floor",
+                        "interior_construction": "Generic Interior Floor",
+                        "ground_construction": "Generic Ground Slab"
+                    },
+                    "roof_ceiling_set": {
+                        "type": "RoofCeilingConstructionSetAbridged",
+                        "exterior_construction": "Generic Roof",
+                        "interior_construction": "Generic Interior Ceiling",
+                        "ground_construction": "Generic Underground Roof"
+                    },
+                    "aperture_set": {
+                        "type": "ApertureConstructionSetAbridged",
+                        "window_construction": "Generic Double Pane",
+                        "interior_construction": "Generic Single Pane",
+                        "skylight_construction": "Generic Double Pane",
+                        "operable_construction": "Generic Double Pane"
+                    },
+                    "door_set": {
+                        "type": "DoorConstructionSetAbridged",
+                        "exterior_construction": "Generic Exterior Door",
+                        "interior_construction": "Generic Interior Door",
+                        "exterior_glass_construction": "Generic Double Pane",
+                        "interior_glass_construction": "Generic Single Pane",
+                        "overhead_construction": "Generic Exterior Door"
+                    },
+                    "shade_construction": "Generic Shade",
+                    "air_boundary_construction": "Generic Air Boundary"
+                }
+            ],
+            "global_construction_set": "Default Generic Construction Set",
+            "constructions": [
+                {
+                    "type": "OpaqueConstructionAbridged",
+                    "identifier": "Generic Exterior Door",
+                    "layers": [
+                        "Generic Painted Metal",
+                        "Generic 25mm Insulation",
+                        "Generic Painted Metal"
+                    ]
+                },
+                {
+                    "type": "OpaqueConstructionAbridged",
+                    "identifier": "Generic Underground Roof",
+                    "layers": [
+                        "Generic 50mm Insulation",
+                        "Generic HW Concrete",
+                        "Generic Ceiling Air Gap",
+                        "Generic Acoustic Tile"
+                    ]
+                },
+                {
+                    "type": "OpaqueConstructionAbridged",
+                    "identifier": "Generic Interior Wall",
+                    "layers": [
+                        "Generic Gypsum Board",
+                        "Generic Wall Air Gap",
+                        "Generic Gypsum Board"
+                    ]
+                },
+                {
+                    "type": "OpaqueConstructionAbridged",
+                    "identifier": "Generic Roof",
+                    "layers": [
+                        "Generic Roof Membrane",
+                        "Generic 50mm Insulation",
+                        "Generic LW Concrete",
+                        "Generic Ceiling Air Gap",
+                        "Generic Acoustic Tile"
+                    ]
+                },
+                {
+                    "type": "OpaqueConstructionAbridged",
+                    "identifier": "Generic Ground Slab",
+                    "layers": [
+                        "Generic 50mm Insulation",
+                        "Generic HW Concrete"
+                    ]
+                },
+                {
+                    "type": "OpaqueConstructionAbridged",
+                    "identifier": "Generic Interior Floor",
+                    "layers": [
+                        "Generic Acoustic Tile",
+                        "Generic Ceiling Air Gap",
+                        "Generic LW Concrete"
+                    ]
+                },
+                {
+                    "type": "WindowConstructionAbridged",
+                    "identifier": "Generic Single Pane",
+                    "layers": [
+                        "Generic Clear Glass"
+                    ]
+                },
+                {
+                    "type": "OpaqueConstructionAbridged",
+                    "identifier": "Generic Interior Door",
+                    "layers": [
+                        "Generic 25mm Wood"
+                    ]
+                },
+                {
+                    "type": "OpaqueConstructionAbridged",
+                    "identifier": "Generic Exposed Floor",
+                    "layers": [
+                        "Generic Painted Metal",
+                        "Generic Ceiling Air Gap",
+                        "Generic 50mm Insulation",
+                        "Generic LW Concrete"
+                    ]
+                },
+                {
+                    "type": "OpaqueConstructionAbridged",
+                    "identifier": "Generic Interior Ceiling",
+                    "layers": [
+                        "Generic LW Concrete",
+                        "Generic Ceiling Air Gap",
+                        "Generic Acoustic Tile"
+                    ]
+                },
+                {
+                    "type": "WindowConstructionAbridged",
+                    "identifier": "Generic Double Pane",
+                    "layers": [
+                        "Generic Low-e Glass",
+                        "Generic Window Air Gap",
+                        "Generic Clear Glass"
+                    ]
+                },
+                {
+                    "type": "AirBoundaryConstructionAbridged",
+                    "identifier": "Generic Air Boundary",
+                    "air_mixing_per_area": 0.1,
+                    "air_mixing_schedule": "Always On"
+                },
+                {
+                    "type": "OpaqueConstructionAbridged",
+                    "identifier": "Generic Exterior Wall",
+                    "layers": [
+                        "Generic Brick",
+                        "Generic LW Concrete",
+                        "Generic 50mm Insulation",
+                        "Generic Wall Air Gap",
+                        "Generic Gypsum Board"
+                    ]
+                },
+                {
+                    "type": "ShadeConstruction",
+                    "identifier": "Generic Shade",
+                    "solar_reflectance": 0.35,
+                    "visible_reflectance": 0.35,
+                    "is_specular": false
+                },
+                {
+                    "type": "OpaqueConstructionAbridged",
+                    "identifier": "Generic Underground Wall",
+                    "layers": [
+                        "Generic 50mm Insulation",
+                        "Generic HW Concrete",
+                        "Generic Wall Air Gap",
+                        "Generic Gypsum Board"
+                    ]
+                }
+            ],
+            "materials": [
+                {
+                    "type": "EnergyMaterial",
+                    "identifier": "Generic 25mm Insulation",
+                    "roughness": "MediumRough",
+                    "thickness": 0.05,
+                    "conductivity": 0.03,
+                    "density": 43.0,
+                    "specific_heat": 1210.0,
+                    "thermal_absorptance": 0.9,
+                    "solar_absorptance": 0.7,
+                    "visible_absorptance": 0.7
+                },
+                {
+                    "type": "EnergyWindowMaterialGas",
+                    "identifier": "Generic Window Air Gap",
+                    "thickness": 0.0127,
+                    "gas_type": "Air"
+                },
+                {
+                    "type": "EnergyMaterial",
+                    "identifier": "Generic Ceiling Air Gap",
+                    "roughness": "Smooth",
+                    "thickness": 0.1,
+                    "conductivity": 0.556,
+                    "density": 1.28,
+                    "specific_heat": 1000.0,
+                    "thermal_absorptance": 0.9,
+                    "solar_absorptance": 0.7,
+                    "visible_absorptance": 0.7
+                },
+                {
+                    "type": "EnergyMaterial",
+                    "identifier": "Generic Roof Membrane",
+                    "roughness": "MediumRough",
+                    "thickness": 0.01,
+                    "conductivity": 0.16,
+                    "density": 1120.0,
+                    "specific_heat": 1460.0,
+                    "thermal_absorptance": 0.9,
+                    "solar_absorptance": 0.65,
+                    "visible_absorptance": 0.65
+                },
+                {
+                    "type": "EnergyMaterial",
+                    "identifier": "Generic Acoustic Tile",
+                    "roughness": "MediumSmooth",
+                    "thickness": 0.02,
+                    "conductivity": 0.06,
+                    "density": 368.0,
+                    "specific_heat": 590.0,
+                    "thermal_absorptance": 0.9,
+                    "solar_absorptance": 0.2,
+                    "visible_absorptance": 0.2
+                },
+                {
+                    "type": "EnergyMaterial",
+                    "identifier": "Generic LW Concrete",
+                    "roughness": "MediumRough",
+                    "thickness": 0.1,
+                    "conductivity": 0.53,
+                    "density": 1280.0,
+                    "specific_heat": 840.0,
+                    "thermal_absorptance": 0.9,
+                    "solar_absorptance": 0.8,
+                    "visible_absorptance": 0.8
+                },
+                {
+                    "type": "EnergyMaterial",
+                    "identifier": "Generic Gypsum Board",
+                    "roughness": "MediumSmooth",
+                    "thickness": 0.0127,
+                    "conductivity": 0.16,
+                    "density": 800.0,
+                    "specific_heat": 1090.0,
+                    "thermal_absorptance": 0.9,
+                    "solar_absorptance": 0.5,
+                    "visible_absorptance": 0.5
+                },
+                {
+                    "type": "EnergyMaterial",
+                    "identifier": "Generic HW Concrete",
+                    "roughness": "MediumRough",
+                    "thickness": 0.2,
+                    "conductivity": 1.95,
+                    "density": 2240.0,
+                    "specific_heat": 900.0,
+                    "thermal_absorptance": 0.9,
+                    "solar_absorptance": 0.8,
+                    "visible_absorptance": 0.8
+                },
+                {
+                    "type": "EnergyMaterial",
+                    "identifier": "Generic 50mm Insulation",
+                    "roughness": "MediumRough",
+                    "thickness": 0.05,
+                    "conductivity": 0.03,
+                    "density": 43.0,
+                    "specific_heat": 1210.0,
+                    "thermal_absorptance": 0.9,
+                    "solar_absorptance": 0.7,
+                    "visible_absorptance": 0.7
+                },
+                {
+                    "type": "EnergyWindowMaterialGlazing",
+                    "identifier": "Generic Low-e Glass",
+                    "thickness": 0.006,
+                    "solar_transmittance": 0.45,
+                    "solar_reflectance": 0.36,
+                    "solar_reflectance_back": 0.36,
+                    "visible_transmittance": 0.71,
+                    "visible_reflectance": 0.21,
+                    "visible_reflectance_back": 0.21,
+                    "infrared_transmittance": 0.0,
+                    "emissivity": 0.84,
+                    "emissivity_back": 0.047,
+                    "conductivity": 1.0,
+                    "dirt_correction": 1.0,
+                    "solar_diffusing": false
+                },
+                {
+                    "type": "EnergyMaterial",
+                    "identifier": "Generic Brick",
+                    "roughness": "MediumRough",
+                    "thickness": 0.1,
+                    "conductivity": 0.9,
+                    "density": 1920.0,
+                    "specific_heat": 790.0,
+                    "thermal_absorptance": 0.9,
+                    "solar_absorptance": 0.65,
+                    "visible_absorptance": 0.65
+                },
+                {
+                    "type": "EnergyMaterial",
+                    "identifier": "Generic 25mm Wood",
+                    "roughness": "MediumSmooth",
+                    "thickness": 0.0254,
+                    "conductivity": 0.15,
+                    "density": 608.0,
+                    "specific_heat": 1630.0,
+                    "thermal_absorptance": 0.9,
+                    "solar_absorptance": 0.5,
+                    "visible_absorptance": 0.5
+                },
+                {
+                    "type": "EnergyMaterial",
+                    "identifier": "Generic Wall Air Gap",
+                    "roughness": "Smooth",
+                    "thickness": 0.1,
+                    "conductivity": 0.667,
+                    "density": 1.28,
+                    "specific_heat": 1000.0,
+                    "thermal_absorptance": 0.9,
+                    "solar_absorptance": 0.7,
+                    "visible_absorptance": 0.7
+                },
+                {
+                    "type": "EnergyWindowMaterialGlazing",
+                    "identifier": "Generic Clear Glass",
+                    "thickness": 0.006,
+                    "solar_transmittance": 0.77,
+                    "solar_reflectance": 0.07,
+                    "solar_reflectance_back": 0.07,
+                    "visible_transmittance": 0.88,
+                    "visible_reflectance": 0.08,
+                    "visible_reflectance_back": 0.08,
+                    "infrared_transmittance": 0.0,
+                    "emissivity": 0.84,
+                    "emissivity_back": 0.84,
+                    "conductivity": 1.0,
+                    "dirt_correction": 1.0,
+                    "solar_diffusing": false
+                },
+                {
+                    "type": "EnergyMaterial",
+                    "identifier": "Generic Painted Metal",
+                    "roughness": "Smooth",
+                    "thickness": 0.0015,
+                    "conductivity": 45.0,
+                    "density": 7690.0,
+                    "specific_heat": 410.0,
+                    "thermal_absorptance": 0.9,
+                    "solar_absorptance": 0.5,
+                    "visible_absorptance": 0.5
+                }
+            ],
+            "hvacs": [],
+            "program_types": [],
+            "schedules": [
+                {
+                    "type": "ScheduleRulesetAbridged",
+                    "identifier": "Always On",
+                    "day_schedules": [
+                        {
+                            "type": "ScheduleDay",
+                            "identifier": "Always On_Day Schedule",
+                            "values": [
+                                1.0
+                            ],
+                            "times": [
+                                [
+                                    0,
+                                    0
+                                ]
+                            ],
+                            "interpolate": false
+                        }
+                    ],
+                    "default_day_schedule": "Always On_Day Schedule",
+                    "schedule_type_limit": "Fractional"
+                }
+            ],
+            "schedule_type_limits": [
+                {
+                    "type": "ScheduleTypeLimit",
+                    "identifier": "Fractional",
+                    "lower_limit": 0.0,
+                    "upper_limit": 1.0,
+                    "numeric_type": "Continuous",
+                    "unit_type": "Dimensionless"
+                }
+            ]
+        },
+        "radiance": {
+            "type": "ModelRadianceProperties",
+            "modifier_sets": [
+                {
+                    "type": "ModifierSetAbridged",
+                    "identifier": "Generic_Interior_Visible_Modifier_Set",
+                    "wall_set": {
+                        "exterior_modifier": "generic_wall_0.50",
+                        "interior_modifier": "generic_wall_0.50",
+                        "type": "WallModifierSetAbridged"
+                    },
+                    "floor_set": {
+                        "exterior_modifier": "generic_floor_0.20",
+                        "interior_modifier": "generic_floor_0.20",
+                        "type": "FloorModifierSetAbridged"
+                    },
+                    "roof_ceiling_set": {
+                        "exterior_modifier": "generic_ceiling_0.80",
+                        "interior_modifier": "generic_ceiling_0.80",
+                        "type": "RoofCeilingModifierSetAbridged"
+                    },
+                    "aperture_set": {
+                        "skylight_modifier": "generic_exterior_window_vis_0.64",
+                        "interior_modifier": "generic_interior_window_vis_0.88",
+                        "operable_modifier": "generic_exterior_window_vis_0.64",
+                        "type": "ApertureModifierSetAbridged",
+                        "window_modifier": "generic_exterior_window_vis_0.64"
+                    },
+                    "door_set": {
+                        "exterior_modifier": "generic_opaque_door_0.50",
+                        "interior_glass_modifier": "generic_interior_window_vis_0.88",
+                        "interior_modifier": "generic_opaque_door_0.50",
+                        "overhead_modifier": "generic_opaque_door_0.50",
+                        "exterior_glass_modifier": "generic_exterior_window_vis_0.64",
+                        "type": "DoorModifierSetAbridged"
+                    },
+                    "shade_set": {
+                        "exterior_modifier": "generic_exterior_shade_0.35",
+                        "interior_modifier": "generic_interior_shade_0.50",
+                        "type": "ShadeModifierSetAbridged"
+                    },
+                    "air_boundary_modifier": "air_boundary"
+                }
+            ],
+            "global_modifier_set": "Generic_Interior_Visible_Modifier_Set",
+            "modifiers": [
+                {
+                    "modifier": null,
+                    "type": "plastic",
+                    "identifier": "generic_opaque_door_0.50",
+                    "r_reflectance": 0.5,
+                    "g_reflectance": 0.5,
+                    "b_reflectance": 0.5,
+                    "specularity": 0.0,
+                    "roughness": 0.0,
+                    "dependencies": []
+                },
+                {
+                    "modifier": null,
+                    "type": "glass",
+                    "identifier": "generic_interior_window_vis_0.88",
+                    "r_transmissivity": 0.9584154328610596,
+                    "g_transmissivity": 0.9584154328610596,
+                    "b_transmissivity": 0.9584154328610596,
+                    "refraction_index": null,
+                    "dependencies": []
+                },
+                {
+                    "modifier": null,
+                    "type": "plastic",
+                    "identifier": "generic_exterior_shade_0.35",
+                    "r_reflectance": 0.35,
+                    "g_reflectance": 0.35,
+                    "b_reflectance": 0.35,
+                    "specularity": 0.0,
+                    "roughness": 0.0,
+                    "dependencies": []
+                },
+                {
+                    "modifier": null,
+                    "type": "plastic",
+                    "identifier": "generic_interior_shade_0.50",
+                    "r_reflectance": 0.5,
+                    "g_reflectance": 0.5,
+                    "b_reflectance": 0.5,
+                    "specularity": 0.0,
+                    "roughness": 0.0,
+                    "dependencies": []
+                },
+                {
+                    "modifier": null,
+                    "type": "plastic",
+                    "identifier": "generic_wall_0.50",
+                    "r_reflectance": 0.5,
+                    "g_reflectance": 0.5,
+                    "b_reflectance": 0.5,
+                    "specularity": 0.0,
+                    "roughness": 0.0,
+                    "dependencies": []
+                },
+                {
+                    "modifier": null,
+                    "type": "plastic",
+                    "identifier": "generic_ceiling_0.80",
+                    "r_reflectance": 0.8,
+                    "g_reflectance": 0.8,
+                    "b_reflectance": 0.8,
+                    "specularity": 0.0,
+                    "roughness": 0.0,
+                    "dependencies": []
+                },
+                {
+                    "modifier": null,
+                    "type": "glass",
+                    "identifier": "generic_exterior_window_vis_0.64",
+                    "r_transmissivity": 0.6975761815384331,
+                    "g_transmissivity": 0.6975761815384331,
+                    "b_transmissivity": 0.6975761815384331,
+                    "refraction_index": null,
+                    "dependencies": []
+                },
+                {
+                    "modifier": null,
+                    "type": "glass",
+                    "identifier": "air_boundary",
+                    "r_transmissivity": 1.0,
+                    "g_transmissivity": 1.0,
+                    "b_transmissivity": 1.0,
+                    "refraction_index": null,
+                    "dependencies": []
+                },
+                {
+                    "modifier": null,
+                    "type": "plastic",
+                    "identifier": "generic_floor_0.20",
+                    "r_reflectance": 0.2,
+                    "g_reflectance": 0.2,
+                    "b_reflectance": 0.2,
+                    "specularity": 0.0,
+                    "roughness": 0.0,
+                    "dependencies": []
+                }
+            ]
+        }
+    },
+    "rooms": [
+        {
+            "type": "Room",
+            "identifier": "TinyHouseZone1",
+            "display_name": "TinyHouseZone1",
+            "properties": {
+                "type": "RoomPropertiesAbridged",
+                "energy": {
+                    "type": "RoomEnergyPropertiesAbridged"
+                },
+                "radiance": {
+                    "type": "RoomRadiancePropertiesAbridged"
+                }
+            },
+            "faces": [
+                {
+                    "type": "Face",
+                    "identifier": "TinyHouseZone1_Bottom",
+                    "display_name": "TinyHouseZone1_Bottom",
+                    "properties": {
+                        "type": "FacePropertiesAbridged",
+                        "energy": {
+                            "type": "FaceEnergyPropertiesAbridged"
+                        },
+                        "radiance": {
+                            "type": "FaceRadiancePropertiesAbridged"
+                        }
+                    },
+                    "geometry": {
+                        "type": "Face3D",
+                        "boundary": [
+                            [
+                                0.0,
+                                0.0,
+                                0.0
+                            ],
+                            [
+                                0.0,
+                                10.0,
+                                0.0
+                            ],
+                            [
+                                5.0,
+                                10.0,
+                                0.0
+                            ],
+                            [
+                                5.0,
+                                0.0,
+                                0.0
+                            ]
+                        ]
+                    },
+                    "face_type": "Floor",
+                    "boundary_condition": {
+                        "type": "Ground"
+                    }
+                },
+                {
+                    "type": "Face",
+                    "identifier": "TinyHouseZone1_Front",
+                    "display_name": "TinyHouseZone1_Front",
+                    "properties": {
+                        "type": "FacePropertiesAbridged",
+                        "energy": {
+                            "type": "FaceEnergyPropertiesAbridged"
+                        },
+                        "radiance": {
+                            "type": "FaceRadiancePropertiesAbridged"
+                        }
+                    },
+                    "geometry": {
+                        "type": "Face3D",
+                        "boundary": [
+                            [
+                                5.0,
+                                10.0,
+                                3.0
+                            ],
+                            [
+                                5.0,
+                                10.0,
+                                0.0
+                            ],
+                            [
+                                0.0,
+                                10.0,
+                                0.0
+                            ],
+                            [
+                                0.0,
+                                10.0,
+                                3.0
+                            ]
+                        ]
+                    },
+                    "face_type": "Wall",
+                    "boundary_condition": {
+                        "type": "Surface",
+                        "boundary_condition_objects": [
+                            "TinyHouseZone2_Back",
+                            "TinyHouseZone2"
+                        ]
+                    },
+                    "apertures": [
+                        {
+                            "type": "Aperture",
+                            "identifier": "FrontAperture",
+                            "display_name": "FrontAperture",
+                            "properties": {
+                                "type": "AperturePropertiesAbridged",
+                                "energy": {
+                                    "type": "ApertureEnergyPropertiesAbridged"
+                                },
+                                "radiance": {
+                                    "type": "ApertureRadiancePropertiesAbridged"
+                                }
+                            },
+                            "geometry": {
+                                "type": "Face3D",
+                                "boundary": [
+                                    [
+                                        4.5,
+                                        10.0,
+                                        2.5
+                                    ],
+                                    [
+                                        4.5,
+                                        10.0,
+                                        1.0
+                                    ],
+                                    [
+                                        2.5,
+                                        10.0,
+                                        1.0
+                                    ],
+                                    [
+                                        2.5,
+                                        10.0,
+                                        2.5
+                                    ],
+                                    [
+                                        3.5,
+                                        10.0,
+                                        2.9
+                                    ]
+                                ]
+                            },
+                            "is_operable": false,
+                            "boundary_condition": {
+                                "type": "Surface",
+                                "boundary_condition_objects": [
+                                    "BackAperture",
+                                    "TinyHouseZone2_Back",
+                                    "TinyHouseZone2"
+                                ]
+                            }
+                        }
+                    ],
+                    "doors": [
+                        {
+                            "type": "Door",
+                            "identifier": "FrontDoor",
+                            "display_name": "FrontDoor",
+                            "properties": {
+                                "type": "DoorPropertiesAbridged",
+                                "energy": {
+                                    "type": "DoorEnergyPropertiesAbridged"
+                                },
+                                "radiance": {
+                                    "type": "DoorRadiancePropertiesAbridged"
+                                }
+                            },
+                            "geometry": {
+                                "type": "Face3D",
+                                "boundary": [
+                                    [
+                                        2.0,
+                                        10.0,
+                                        2.5
+                                    ],
+                                    [
+                                        2.0,
+                                        10.0,
+                                        0.1
+                                    ],
+                                    [
+                                        1.0,
+                                        10.0,
+                                        0.1
+                                    ],
+                                    [
+                                        1.0,
+                                        10.0,
+                                        2.5
+                                    ],
+                                    [
+                                        1.5,
+                                        10.0,
+                                        2.8
+                                    ]
+                                ]
+                            },
+                            "is_glass": false,
+                            "boundary_condition": {
+                                "type": "Surface",
+                                "boundary_condition_objects": [
+                                    "BackDoor",
+                                    "TinyHouseZone2_Back",
+                                    "TinyHouseZone2"
+                                ]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "type": "Face",
+                    "identifier": "TinyHouseZone1_Right",
+                    "display_name": "TinyHouseZone1_Right",
+                    "properties": {
+                        "type": "FacePropertiesAbridged",
+                        "energy": {
+                            "type": "FaceEnergyPropertiesAbridged"
+                        },
+                        "radiance": {
+                            "type": "FaceRadiancePropertiesAbridged"
+                        }
+                    },
+                    "geometry": {
+                        "type": "Face3D",
+                        "boundary": [
+                            [
+                                5.0,
+                                0.0,
+                                3.0
+                            ],
+                            [
+                                5.0,
+                                0.0,
+                                0.0
+                            ],
+                            [
+                                5.0,
+                                10.0,
+                                0.0
+                            ],
+                            [
+                                5.0,
+                                10.0,
+                                3.0
+                            ]
+                        ]
+                    },
+                    "face_type": "Wall",
+                    "boundary_condition": {
+                        "type": "Outdoors",
+                        "sun_exposure": true,
+                        "wind_exposure": true,
+                        "view_factor": {
+                            "type": "Autocalculate"
+                        }
+                    }
+                },
+                {
+                    "type": "Face",
+                    "identifier": "TinyHouseZone1_Back",
+                    "display_name": "TinyHouseZone1_Back",
+                    "properties": {
+                        "type": "FacePropertiesAbridged",
+                        "energy": {
+                            "type": "FaceEnergyPropertiesAbridged"
+                        },
+                        "radiance": {
+                            "type": "FaceRadiancePropertiesAbridged"
+                        }
+                    },
+                    "geometry": {
+                        "type": "Face3D",
+                        "boundary": [
+                            [
+                                0.0,
+                                0.0,
+                                3.0
+                            ],
+                            [
+                                0.0,
+                                0.0,
+                                0.0
+                            ],
+                            [
+                                5.0,
+                                0.0,
+                                0.0
+                            ],
+                            [
+                                5.0,
+                                0.0,
+                                3.0
+                            ]
+                        ]
+                    },
+                    "face_type": "Wall",
+                    "boundary_condition": {
+                        "type": "Outdoors",
+                        "sun_exposure": true,
+                        "wind_exposure": true,
+                        "view_factor": {
+                            "type": "Autocalculate"
+                        }
+                    }
+                },
+                {
+                    "type": "Face",
+                    "identifier": "TinyHouseZone1_Left",
+                    "display_name": "TinyHouseZone1_Left",
+                    "properties": {
+                        "type": "FacePropertiesAbridged",
+                        "energy": {
+                            "type": "FaceEnergyPropertiesAbridged"
+                        },
+                        "radiance": {
+                            "type": "FaceRadiancePropertiesAbridged"
+                        }
+                    },
+                    "geometry": {
+                        "type": "Face3D",
+                        "boundary": [
+                            [
+                                0.0,
+                                10.0,
+                                3.0
+                            ],
+                            [
+                                0.0,
+                                10.0,
+                                0.0
+                            ],
+                            [
+                                0.0,
+                                0.0,
+                                0.0
+                            ],
+                            [
+                                0.0,
+                                0.0,
+                                3.0
+                            ]
+                        ]
+                    },
+                    "face_type": "Wall",
+                    "boundary_condition": {
+                        "type": "Outdoors",
+                        "sun_exposure": true,
+                        "wind_exposure": true,
+                        "view_factor": {
+                            "type": "Autocalculate"
+                        }
+                    }
+                },
+                {
+                    "type": "Face",
+                    "identifier": "TinyHouseZone1_Top",
+                    "display_name": "TinyHouseZone1_Top",
+                    "properties": {
+                        "type": "FacePropertiesAbridged",
+                        "energy": {
+                            "type": "FaceEnergyPropertiesAbridged"
+                        },
+                        "radiance": {
+                            "type": "FaceRadiancePropertiesAbridged"
+                        }
+                    },
+                    "geometry": {
+                        "type": "Face3D",
+                        "boundary": [
+                            [
+                                5.0,
+                                0.0,
+                                3.0
+                            ],
+                            [
+                                5.0,
+                                10.0,
+                                3.0
+                            ],
+                            [
+                                0.0,
+                                10.0,
+                                3.0
+                            ],
+                            [
+                                0.0,
+                                0.0,
+                                3.0
+                            ]
+                        ]
+                    },
+                    "face_type": "RoofCeiling",
+                    "boundary_condition": {
+                        "type": "Outdoors",
+                        "sun_exposure": true,
+                        "wind_exposure": true,
+                        "view_factor": {
+                            "type": "Autocalculate"
+                        }
+                    }
+                }
+            ]
+        },
+        {
+            "type": "Room",
+            "identifier": "TinyHouseZone2",
+            "display_name": "TinyHouseZone2",
+            "properties": {
+                "type": "RoomPropertiesAbridged",
+                "energy": {
+                    "type": "RoomEnergyPropertiesAbridged"
+                },
+                "radiance": {
+                    "type": "RoomRadiancePropertiesAbridged"
+                }
+            },
+            "faces": [
+                {
+                    "type": "Face",
+                    "identifier": "TinyHouseZone2_Bottom",
+                    "display_name": "TinyHouseZone2_Bottom",
+                    "properties": {
+                        "type": "FacePropertiesAbridged",
+                        "energy": {
+                            "type": "FaceEnergyPropertiesAbridged"
+                        },
+                        "radiance": {
+                            "type": "FaceRadiancePropertiesAbridged"
+                        }
+                    },
+                    "geometry": {
+                        "type": "Face3D",
+                        "boundary": [
+                            [
+                                0.0,
+                                10.0,
+                                0.0
+                            ],
+                            [
+                                0.0,
+                                20.0,
+                                0.0
+                            ],
+                            [
+                                5.0,
+                                20.0,
+                                0.0
+                            ],
+                            [
+                                5.0,
+                                10.0,
+                                0.0
+                            ]
+                        ]
+                    },
+                    "face_type": "Floor",
+                    "boundary_condition": {
+                        "type": "Ground"
+                    }
+                },
+                {
+                    "type": "Face",
+                    "identifier": "TinyHouseZone2_Front",
+                    "display_name": "TinyHouseZone2_Front",
+                    "properties": {
+                        "type": "FacePropertiesAbridged",
+                        "energy": {
+                            "type": "FaceEnergyPropertiesAbridged"
+                        },
+                        "radiance": {
+                            "type": "FaceRadiancePropertiesAbridged"
+                        }
+                    },
+                    "geometry": {
+                        "type": "Face3D",
+                        "boundary": [
+                            [
+                                5.0,
+                                20.0,
+                                3.0
+                            ],
+                            [
+                                5.0,
+                                20.0,
+                                0.0
+                            ],
+                            [
+                                0.0,
+                                20.0,
+                                0.0
+                            ],
+                            [
+                                0.0,
+                                20.0,
+                                3.0
+                            ]
+                        ]
+                    },
+                    "face_type": "Wall",
+                    "boundary_condition": {
+                        "type": "Outdoors",
+                        "sun_exposure": true,
+                        "wind_exposure": true,
+                        "view_factor": {
+                            "type": "Autocalculate"
+                        }
+                    }
+                },
+                {
+                    "type": "Face",
+                    "identifier": "TinyHouseZone2_Right",
+                    "display_name": "TinyHouseZone2_Right",
+                    "properties": {
+                        "type": "FacePropertiesAbridged",
+                        "energy": {
+                            "type": "FaceEnergyPropertiesAbridged"
+                        },
+                        "radiance": {
+                            "type": "FaceRadiancePropertiesAbridged"
+                        }
+                    },
+                    "geometry": {
+                        "type": "Face3D",
+                        "boundary": [
+                            [
+                                5.0,
+                                10.0,
+                                3.0
+                            ],
+                            [
+                                5.0,
+                                10.0,
+                                0.0
+                            ],
+                            [
+                                5.0,
+                                20.0,
+                                0.0
+                            ],
+                            [
+                                5.0,
+                                20.0,
+                                3.0
+                            ]
+                        ]
+                    },
+                    "face_type": "Wall",
+                    "boundary_condition": {
+                        "type": "Outdoors",
+                        "sun_exposure": true,
+                        "wind_exposure": true,
+                        "view_factor": {
+                            "type": "Autocalculate"
+                        }
+                    }
+                },
+                {
+                    "type": "Face",
+                    "identifier": "TinyHouseZone2_Back",
+                    "display_name": "TinyHouseZone2_Back",
+                    "properties": {
+                        "type": "FacePropertiesAbridged",
+                        "energy": {
+                            "type": "FaceEnergyPropertiesAbridged"
+                        },
+                        "radiance": {
+                            "type": "FaceRadiancePropertiesAbridged"
+                        }
+                    },
+                    "geometry": {
+                        "type": "Face3D",
+                        "boundary": [
+                            [
+                                0.0,
+                                10.0,
+                                3.0
+                            ],
+                            [
+                                0.0,
+                                10.0,
+                                0.0
+                            ],
+                            [
+                                5.0,
+                                10.0,
+                                0.0
+                            ],
+                            [
+                                5.0,
+                                10.0,
+                                3.0
+                            ]
+                        ]
+                    },
+                    "face_type": "Wall",
+                    "boundary_condition": {
+                        "type": "Surface",
+                        "boundary_condition_objects": [
+                            "TinyHouseZone1_Front",
+                            "TinyHouseZone1"
+                        ]
+                    },
+                    "apertures": [
+                        {
+                            "type": "Aperture",
+                            "identifier": "BackAperture",
+                            "display_name": "BackAperture",
+                            "properties": {
+                                "type": "AperturePropertiesAbridged",
+                                "energy": {
+                                    "type": "ApertureEnergyPropertiesAbridged"
+                                },
+                                "radiance": {
+                                    "type": "ApertureRadiancePropertiesAbridged"
+                                }
+                            },
+                            "geometry": {
+                                "type": "Face3D",
+                                "boundary": [
+                                    [
+                                        2.5,
+                                        10.0,
+                                        2.5
+                                    ],
+                                    [
+                                        2.5,
+                                        10.0,
+                                        1.0
+                                    ],
+                                    [
+                                        4.5,
+                                        10.0,
+                                        1.0
+                                    ],
+                                    [
+                                        4.5,
+                                        10.0,
+                                        2.5
+                                    ],
+                                    [
+                                        3.5,
+                                        10.0,
+                                        2.9
+                                    ]
+                                ]
+                            },
+                            "is_operable": false,
+                            "boundary_condition": {
+                                "type": "Surface",
+                                "boundary_condition_objects": [
+                                    "FrontAperture",
+                                    "TinyHouseZone1_Front",
+                                    "TinyHouseZone1"
+                                ]
+                            }
+                        }
+                    ],
+                    "doors": [
+                        {
+                            "type": "Door",
+                            "identifier": "BackDoor",
+                            "display_name": "BackDoor",
+                            "properties": {
+                                "type": "DoorPropertiesAbridged",
+                                "energy": {
+                                    "type": "DoorEnergyPropertiesAbridged"
+                                },
+                                "radiance": {
+                                    "type": "DoorRadiancePropertiesAbridged"
+                                }
+                            },
+                            "geometry": {
+                                "type": "Face3D",
+                                "boundary": [
+                                    [
+                                        1.0,
+                                        10.0,
+                                        2.5
+                                    ],
+                                    [
+                                        1.0,
+                                        10.0,
+                                        0.1
+                                    ],
+                                    [
+                                        2.0,
+                                        10.0,
+                                        0.1
+                                    ],
+                                    [
+                                        2.0,
+                                        10.0,
+                                        2.5
+                                    ],
+                                    [
+                                        1.5,
+                                        10.0,
+                                        2.8
+                                    ]
+                                ]
+                            },
+                            "is_glass": false,
+                            "boundary_condition": {
+                                "type": "Surface",
+                                "boundary_condition_objects": [
+                                    "FrontDoor",
+                                    "TinyHouseZone1_Front",
+                                    "TinyHouseZone1"
+                                ]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "type": "Face",
+                    "identifier": "TinyHouseZone2_Left",
+                    "display_name": "TinyHouseZone2_Left",
+                    "properties": {
+                        "type": "FacePropertiesAbridged",
+                        "energy": {
+                            "type": "FaceEnergyPropertiesAbridged"
+                        },
+                        "radiance": {
+                            "type": "FaceRadiancePropertiesAbridged"
+                        }
+                    },
+                    "geometry": {
+                        "type": "Face3D",
+                        "boundary": [
+                            [
+                                0.0,
+                                20.0,
+                                3.0
+                            ],
+                            [
+                                0.0,
+                                20.0,
+                                0.0
+                            ],
+                            [
+                                0.0,
+                                10.0,
+                                0.0
+                            ],
+                            [
+                                0.0,
+                                10.0,
+                                3.0
+                            ]
+                        ]
+                    },
+                    "face_type": "Wall",
+                    "boundary_condition": {
+                        "type": "Outdoors",
+                        "sun_exposure": true,
+                        "wind_exposure": true,
+                        "view_factor": {
+                            "type": "Autocalculate"
+                        }
+                    }
+                },
+                {
+                    "type": "Face",
+                    "identifier": "TinyHouseZone2_Top",
+                    "display_name": "TinyHouseZone2_Top",
+                    "properties": {
+                        "type": "FacePropertiesAbridged",
+                        "energy": {
+                            "type": "FaceEnergyPropertiesAbridged"
+                        },
+                        "radiance": {
+                            "type": "FaceRadiancePropertiesAbridged"
+                        }
+                    },
+                    "geometry": {
+                        "type": "Face3D",
+                        "boundary": [
+                            [
+                                5.0,
+                                10.0,
+                                3.0
+                            ],
+                            [
+                                5.0,
+                                20.0,
+                                3.0
+                            ],
+                            [
+                                0.0,
+                                20.0,
+                                3.0
+                            ],
+                            [
+                                0.0,
+                                10.0,
+                                3.0
+                            ]
+                        ]
+                    },
+                    "face_type": "RoofCeiling",
+                    "boundary_condition": {
+                        "type": "Outdoors",
+                        "sun_exposure": true,
+                        "wind_exposure": true,
+                        "view_factor": {
+                            "type": "Autocalculate"
+                        }
+                    }
+                }
+            ]
+        }
+    ]
+}

--- a/samples/simulation_parameter/simulation_par_detailed.json
+++ b/samples/simulation_parameter/simulation_par_detailed.json
@@ -69,7 +69,7 @@
     },
     "shadow_calculation": {
         "type": "ShadowCalculation",
-        "solar_distribution": "FullInteriorAndExteriorWithReflections",
+        "solar_distribution": "FullExteriorWithReflections",
         "calculation_method": "AverageOverDaysInFrequency",
         "calculation_frequency": 20,
         "maximum_figures": 15000

--- a/samples/simulation_parameter/simulation_par_simple.json
+++ b/samples/simulation_parameter/simulation_par_simple.json
@@ -33,7 +33,7 @@
     },
     "shadow_calculation": {
         "type": "ShadowCalculation",
-        "solar_distribution": "FullInteriorAndExteriorWithReflections",
+        "solar_distribution": "FullExteriorWithReflections",
         "calculation_method": "AverageOverDaysInFrequency",
         "calculation_frequency": 30,
         "maximum_figures": 15000

--- a/scripts/sample_model.py
+++ b/scripts/sample_model.py
@@ -553,6 +553,34 @@ def model_5vertex_sub_faces(directory):
         json.dump(model_dict, fp, indent=4)
 
 
+def model_5vertex_sub_faces_interior(directory):
+    room1 = Room.from_box('TinyHouseZone1', 5, 10, 3)
+    north_face = room1[1]
+    aperture_verts = [Point3D(4.5, 10, 1), Point3D(2.5, 10, 1), Point3D(2.5, 10, 2.5),
+                      Point3D(3.5, 10, 2.9), Point3D(4.5, 10, 2.5)]
+    aperture = Aperture('FrontAperture', Face3D(aperture_verts))
+    north_face.add_aperture(aperture)
+    door_verts = [Point3D(2, 10, 0.1), Point3D(1, 10, 0.1), Point3D(1, 10, 2.5),
+                  Point3D(1.5, 10, 2.8), Point3D(2, 10, 2.5)]
+    door = Door('FrontDoor', Face3D(door_verts))
+    north_face.add_door(door)
+
+    room2 = Room.from_box('TinyHouseZone2', 5, 10, 3, origin=Point3D(0, 10, 0))
+    south_face = room2[3]
+    s_aperture = Aperture('BackAperture', Face3D(aperture_verts))
+    south_face.add_aperture(s_aperture)
+    s_door = Door('BackDoor', Face3D(door_verts))
+    south_face.add_door(s_door)
+
+    Room.solve_adjacency([room1, room2], 0.01)
+    
+    model = Model('TinyHouse', [room1, room2])
+    model_dict = model.to_dict()
+
+    dest_file = os.path.join(directory, 'model_5vertex_sub_faces_interior.json')
+    with open(dest_file, 'w') as fp:
+        json.dump(model_dict, fp, indent=4)
+
 
 
 
@@ -572,7 +600,7 @@ model_energy_fixed_interval(sample_directory)
 model_energy_no_program(sample_directory)
 model_energy_properties_office(sample_directory)
 model_5vertex_sub_faces(sample_directory)
-
+model_5vertex_sub_faces_interior(sample_directory)
 
 model_complete_multiroom_radiance(sample_directory)
 model_radiance_dynamic_states(sample_directory)


### PR DESCRIPTION
The more that I have thought about this, there appear to be more cases where our legacy default of FullInteriorAndExteriorWothReflections doesn't add much accuracy. At the same time, it can really increase simulation time and the risk of severe errors. The interior reflections are overkill for most studies of energy use, thermal loads, and HVAC size. They are also probably overkill for thermal comfort studies using the averaged results over a zone.