### PR TITLE
docs(assets): Add SensorGrid and View to the online schema docs

### DIFF
--- a/docs.py
+++ b/docs.py
@@ -3,6 +3,7 @@ from pkg_resources import get_distribution
 from honeybee_schema._openapi import get_openapi, class_mapper
 from honeybee_schema.model import Model
 from honeybee_schema.energy.simulation import SimulationParameter
+from honeybee_schema.radiance.asset import SensorGrid, View
 
 import json
 import argparse
@@ -105,3 +106,67 @@ with open('./docs/simulation-parameter_inheritance.json', 'w') as out_file:
 # add the mapper file
 with open('./docs/simulation-parameter_mapper.json', 'w') as out_file:
     json.dump(class_mapper(SimulationParameter), out_file, indent=2)
+
+
+# generate Radiance SensorGrid open api schema
+print('Generating Radiance SensorGrid documentation...')
+
+external_docs = {
+    "description": "OpenAPI Specification with Inheritance",
+    "url": "./sensor-grid_inheritance.json"
+}
+
+openapi = get_openapi(
+    [SensorGrid],
+    title='Honeybee Radiance SensorGrid Schema',
+    description='This is the documentation for Honeybee SensorGrid schema.',
+    version=VERSION, info=info,
+    external_docs=external_docs)
+with open('./docs/sensor-grid.json', 'w') as out_file:
+    json.dump(openapi, out_file, indent=2)
+
+openapi = get_openapi(
+    [SensorGrid],
+    title='Honeybee Radiance SensorGrid Schema',
+    description='This is the documentation for Honeybee SensorGrid schema.',
+    version=VERSION, inheritance=True, info=info,
+    external_docs=external_docs
+)
+with open('./docs/sensor-grid_inheritance.json', 'w') as out_file:
+    json.dump(openapi, out_file, indent=2)
+
+# add the mapper file
+with open('./docs/sensor-grid_mapper.json', 'w') as out_file:
+    json.dump(class_mapper(SensorGrid), out_file, indent=2)
+
+
+# generate Radiance View open api schema
+print('Generating Radiance View documentation...')
+
+external_docs = {
+    "description": "OpenAPI Specification with Inheritance",
+    "url": "./view_inheritance.json"
+}
+
+openapi = get_openapi(
+    [View],
+    title='Honeybee Radiance View Schema',
+    description='This is the documentation for Honeybee View schema.',
+    version=VERSION, info=info,
+    external_docs=external_docs)
+with open('./docs/view.json', 'w') as out_file:
+    json.dump(openapi, out_file, indent=2)
+
+openapi = get_openapi(
+    [View],
+    title='Honeybee Radiance View Schema',
+    description='This is the documentation for Honeybee View schema.',
+    version=VERSION, inheritance=True, info=info,
+    external_docs=external_docs
+)
+with open('./docs/view_inheritance.json', 'w') as out_file:
+    json.dump(openapi, out_file, indent=2)
+
+# add the mapper file
+with open('./docs/view_mapper.json', 'w') as out_file:
+    json.dump(class_mapper(View), out_file, indent=2)

--- a/docs/index.html
+++ b/docs/index.html
@@ -62,7 +62,9 @@
 </div>
 <div class="doc-link">
   <a href="./model.html">Model Schema</a><br>
-  <a href="./simulation-parameter.html">Energy Simulation Parameter Schema</a>
+  <a href="./simulation-parameter.html">Energy Simulation Parameter Schema</a><br>
+  <a href="./sensor-grid.html">Radiance Sensor Grid Schema</a><br>
+  <a href="./view.html">Radiance View Schema</a><br>
 </div>
 </body>
 </html>

--- a/docs/sensor-grid.html
+++ b/docs/sensor-grid.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
 <head>
-<title>Honeybee Energy Simulation Parameter Schema</title>
+<title>Honeybee Radiance Sensor Grid Schema</title>
 <!-- needed for adaptive design -->
 <meta charset="utf-8"/>
 <meta name="viewport" content="width=device-width, initial-scale=1">
@@ -17,7 +17,7 @@
 </style>
 </head>
 <body>
-<redoc spec-url="./simulation-parameter.json"></redoc>
+<redoc spec-url="./sensor-grid.json"></redoc>
 <script src="https://cdn.jsdelivr.net/npm/redoc@next/bundles/redoc.standalone.js"> </script>
 </body>
 </html>

--- a/docs/view.html
+++ b/docs/view.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
 <head>
-<title>Honeybee Energy Simulation Parameter Schema</title>
+<title>Honeybee Radiance View Schema</title>
 <!-- needed for adaptive design -->
 <meta charset="utf-8"/>
 <meta name="viewport" content="width=device-width, initial-scale=1">
@@ -17,7 +17,7 @@
 </style>
 </head>
 <body>
-<redoc spec-url="./simulation-parameter.json"></redoc>
+<redoc spec-url="./view.json"></redoc>
 <script src="https://cdn.jsdelivr.net/npm/redoc@next/bundles/redoc.standalone.js"> </script>
 </body>
 </html>

--- a/honeybee_schema/radiance/asset.py
+++ b/honeybee_schema/radiance/asset.py
@@ -6,6 +6,30 @@ from .._base import NoExtraBaseModel
 from ._base import IDdRadianceBaseModel
 
 
+class _RadianceAsset(IDdRadianceBaseModel):
+    """Hidden base class for all Radiance Assets."""
+
+    room_identifier: str = Field(
+        None,
+        regex=r'[A-Za-z0-9_-]',
+        min_length=1,
+        max_length=100,
+        description='Optional text string for the Room identifier to which this '
+        'object belongs. This will be used to narrow down the number of '
+        'aperture groups that have to be run with this sensor grid. If None, '
+        'the grid will be run with all aperture groups in the model.'
+    )
+
+    light_path: List[List[str]] = Field(
+        None,
+        description='Get or set a list of lists for the light path from the object to '
+        'the sky. Each sub-list contains identifiers of aperture groups through which '
+        'light passes. (eg. [["SouthWindow1"], ["static_apertures", "NorthWindow2"]]).'
+        'Setting this property will override any auto-calculation of the light '
+        'path from the model and room_identifier upon export to the simulation.'
+    )
+
+
 class Sensor(NoExtraBaseModel):
     """A single Radiance of sensors."""
 
@@ -26,7 +50,7 @@ class Sensor(NoExtraBaseModel):
     )
 
 
-class SensorGrid(IDdRadianceBaseModel):
+class SensorGrid(_RadianceAsset):
     """A grid of sensors."""
 
     type: constr(regex='^SensorGrid$') = 'SensorGrid'
@@ -34,26 +58,6 @@ class SensorGrid(IDdRadianceBaseModel):
     sensors: List[Sensor] = Field(
         ...,
         description="A list of sensors that belong to the grid."
-    )
-
-    room_identifier: str = Field(
-        None,
-        regex=r'[A-Za-z0-9_-]',
-        min_length=1,
-        max_length=100,
-        description='Optional text string for the Room identifier to which this '
-        'SensorGrid belongs. This will be used to narrow down the number of '
-        'aperture groups that have to be run with this sensor grid. If None, '
-        'the grid will be run with all aperture groups in the model.'
-    )
-
-    light_path: List[List[str]] = Field(
-        None,
-        description='Get or set a list of lists for the light path from the grid to the '
-        'sky. Each sub-list contains identifiers of aperture groups through which '
-        'light passes. (eg. [["SouthWindow1"], ["static_apertures", "NorthWindow2"]]).'
-        'Setting this property will override any auto-calculation of the light '
-        'path from the model and room_identifier upon export to the simulation.'
     )
 
 
@@ -67,7 +71,7 @@ class ViewType(str, Enum):
     planisphere = 's'
 
 
-class View(IDdRadianceBaseModel):
+class View(_RadianceAsset):
     """A single Radiance of sensors."""
 
     type: constr(regex='^View$') = 'View'
@@ -151,24 +155,4 @@ class View(IDdRadianceBaseModel):
         'direction for perspective and parallel view types. For fisheye '
         'view types, the clipping plane is actually a clipping sphere, '
         'centered on the view point with radius val.'
-    )
-
-    room_identifier: str = Field(
-        None,
-        regex=r'[A-Za-z0-9_-]',
-        min_length=1,
-        max_length=100,
-        description='Optional text string for the Room identifier to which this '
-        'View belongs. This will be used to narrow down the number of aperture '
-        'groups that have to be run with this sensor grid. If None, the grid '
-        'will be run with all aperture groups in the model.'
-    )
-
-    light_path: List[List[str]] = Field(
-        None,
-        description='Get or set a list of lists for the light path from the view to the '
-        'sky. Each sub-list contains identifiers of aperture groups through which '
-        'light passes. (eg. [["SouthWindow1"], ["static_apertures", "NorthWindow2"]]).'
-        'Setting this property will override any auto-calculation of the light '
-        'path from the model and room_identifier upon export to the simulation.'
     )


### PR DESCRIPTION
This commit will add the SensorGrid and View schemas to the online docs.

I also realized I could cut down the code a bit in the radiance.asset module by using inheritance.

Resolves https://github.com/ladybug-tools/honeybee-schema/issues/135