### PR TITLE
fix(simulationparameter): Change default to include html

### DIFF
--- a/honeybee_schema/energy/simulation.py
+++ b/honeybee_schema/energy/simulation.py
@@ -30,7 +30,7 @@ class SimulationOutput(NoExtraBaseModel):
     )
 
     include_html: bool = Field(
-        default=False,
+        default=True,
         description='Boolean to note whether an HTML report should be requested '
             'from the simulation.'
     )


### PR DESCRIPTION
I realized it really doesn't add to the simulation time much and it's better to have it there if people want it.