### PR TITLE
feat(energy): Upgrade ShadowClaculation schema to use OpenStudio 3.0

### DIFF
--- a/honeybee_schema/energy/simulation.py
+++ b/honeybee_schema/energy/simulation.py
@@ -89,8 +89,13 @@ class SolarDistribution(str, Enum):
 
 
 class CalculationMethod(str, Enum):
-    average_over_days_in_frequency = 'AverageOverDaysInFrequency'
-    timestep_frequency = 'TimestepFrequency'
+    polygon_clipping = 'PolygonClipping'
+    pixel_counting = 'PixelCounting'
+
+
+class CalculationUpdateMethod(str, Enum):
+    periodic = 'Periodic'
+    timestep = 'Timestep'
 
 
 class ShadowCalculation(NoExtraBaseModel):
@@ -101,16 +106,30 @@ class ShadowCalculation(NoExtraBaseModel):
     solar_distribution: SolarDistribution = \
         SolarDistribution.full_exterior_with_reflection
 
+    calculation_method: CalculationMethod = Field(
+        CalculationMethod.polygon_clipping,
+        description='Text noting whether CPU-based polygon clipping method or'
+            'GPU-based pixel counting method should be used. For low numbers of shading'
+            'surfaces (less than ~200), PolygonClipping requires less runtime than'
+            'PixelCounting. However, PixelCounting runtime scales significantly'
+            'better at higher numbers of shading surfaces. PixelCounting also has'
+            'no limitations related to zone concavity when used with any'
+            '“FullInterior” solar distribution options.'
+    )
+
+    calculation_update_method: CalculationUpdateMethod = Field(
+        CalculationUpdateMethod.periodic,
+        description='Text describing how often the solar and shading calculations '
+            'are updated with respect to the flow of time in the simulation.'
+    )
+
     calculation_frequency: int = Field(
         30,
         ge=1,
         description='Integer for the number of days in each period for which a '
             'unique shadow calculation will be performed. This field is only used '
-            'if the AverageOverDaysInFrequency calculation_method is used.'
+            'if the Periodic calculation_method is used.'
     )
-
-    calculation_method: CalculationMethod = \
-        CalculationMethod.average_over_days_in_frequency
 
     maximum_figures: int = Field(
         15000,

--- a/samples/simulation_parameter/simulation_par_detailed.json
+++ b/samples/simulation_parameter/simulation_par_detailed.json
@@ -69,9 +69,10 @@
     },
     "shadow_calculation": {
         "type": "ShadowCalculation",
-        "solar_distribution": "FullExteriorWithReflections",
-        "calculation_method": "AverageOverDaysInFrequency",
-        "calculation_frequency": 20,
+        "solar_distribution": "FullInteriorAndExteriorWithReflections",
+        "calculation_method": "PixelCounting",
+        "calculation_update_method": "Timestep",
+        "calculation_frequency": 30,
         "maximum_figures": 15000
     },
     "sizing_parameter": {

--- a/samples/simulation_parameter/simulation_par_simple.json
+++ b/samples/simulation_parameter/simulation_par_simple.json
@@ -4,7 +4,7 @@
         "type": "SimulationOutput",
         "reporting_frequency": "Hourly",
         "include_sqlite": true,
-        "include_html": false,
+        "include_html": true,
         "summary_reports": [
             "AllSummary"
         ]
@@ -34,7 +34,8 @@
     "shadow_calculation": {
         "type": "ShadowCalculation",
         "solar_distribution": "FullExteriorWithReflections",
-        "calculation_method": "AverageOverDaysInFrequency",
+        "calculation_method": "PolygonClipping",
+        "calculation_update_method": "Periodic",
         "calculation_frequency": 30,
         "maximum_figures": 15000
     },

--- a/scripts/sample_simulation.py
+++ b/scripts/sample_simulation.py
@@ -40,7 +40,9 @@ def simulation_par_detailed(directory):
     sim_control_alt = SimulationControl(run_for_sizing_periods=True,
                                         run_for_run_periods=False)
     sim_par.simulation_control = sim_control_alt
-    shadow_calc_alt = ShadowCalculation(calculation_frequency=20)
+    shadow_calc_alt = ShadowCalculation(
+        solar_distribution='FullInteriorAndExteriorWithReflections',
+        calculation_method='PixelCounting', calculation_update_method='Timestep')
     sim_par.shadow_calculation = shadow_calc_alt
     sizing_alt = SizingParameter(None, 1, 1)
     relative_path = './scripts/ddy/chicago.ddy'


### PR DESCRIPTION
This commit upgrades the ShadowCalculation schema such that it can work with OpenStudio 3.0 and EnergyPlus 9.3.

@MingboPeng  and @mostaphaRoudsari . I wasn't expecting feedback on the commit but I requested your review since I wanted you to be aware that this seems to be the only schema change that was needed to upgrade to OpenStudio 3.0.