### PR TITLE
feat(construction): Add WindowConstructionShade schema

### DIFF
--- a/honeybee_schema/energy/construction.py
+++ b/honeybee_schema/energy/construction.py
@@ -1,13 +1,42 @@
 """Construction Schema"""
-from pydantic import Field, constr
+from pydantic import Field, constr, root_validator
 from typing import List, Union
+from enum import Enum
 
 from ._base import IDdEnergyBaseModel
 from .material import EnergyMaterial, EnergyMaterialNoMass, \
     EnergyWindowMaterialGas, EnergyWindowMaterialGasCustom, \
     EnergyWindowMaterialGasMixture, EnergyWindowMaterialSimpleGlazSys, \
-    EnergyWindowMaterialGlazing
+    EnergyWindowMaterialGlazing, EnergyWindowMaterialShade, EnergyWindowMaterialBlind
 from .schedule import ScheduleRuleset, ScheduleFixedInterval
+
+
+class OpaqueConstructionAbridged(IDdEnergyBaseModel):
+    """Construction for opaque objects (Face, Shade, Door)."""
+
+    type: constr(regex='^OpaqueConstructionAbridged$') = 'OpaqueConstructionAbridged'
+
+    layers: List[constr(min_length=1, max_length=100)] = Field(
+        ...,
+        description='List of strings for opaque material identifiers. The order '
+        'of the materials is from exterior to interior.',
+        min_items=1,
+        max_items=10
+    )
+
+
+class OpaqueConstruction(OpaqueConstructionAbridged):
+    """Construction for opaque objects (Face, Shade, Door)."""
+
+    type: constr(regex='^OpaqueConstruction$') = 'OpaqueConstruction'
+
+    materials: List[Union[EnergyMaterial, EnergyMaterialNoMass]] = Field(
+        ...,
+        description='List of opaque materials. The order of the materials is '
+        'from outside to inside.',
+        min_items=1,
+        max_items=10
+    )
 
 
 class WindowConstructionAbridged(IDdEnergyBaseModel):
@@ -49,32 +78,142 @@ class WindowConstruction(WindowConstructionAbridged):
     )
 
 
-class OpaqueConstructionAbridged(IDdEnergyBaseModel):
-    """Construction for opaque objects (Face, Shade, Door)."""
+class ShadeLocation(str, Enum):
+    """Choices for where a shade material is located in a window assembly."""
+    interior = 'Interior'
+    between = 'Between'
+    exterior = 'Exterior'
 
-    type: constr(regex='^OpaqueConstructionAbridged$') = 'OpaqueConstructionAbridged'
 
-    layers: List[constr(min_length=1, max_length=100)] = Field(
+class ControlType(str, Enum):
+    """Choices for how the shading device is controlled."""
+    always_on = 'AlwaysOn'
+    on_if_high_solar_on_window = 'OnIfHighSolarOnWindow'
+    on_if_high_horizontal_solar = 'OnIfHighHorizontalSolar'
+    on_if_high_outdoor_air_temperature = 'OnIfHighOutdoorAirTemperature'
+    on_if_high_zone_air_temperature = 'OnIfHighZoneAirTemperature'
+    on_if_high_zone_cooling = 'OnIfHighZoneCooling'
+    on_night_if_low_outdoor_temp_and_off_day = 'OnNightIfLowOutdoorTempAndOffDay'
+    on_night_if_low_inside_temp_and_off_day = 'OnNightIfLowInsideTempAndOffDay'
+    on_night_if_heating_and_off_day = 'OnNightIfHeatingAndOffDay'
+
+
+class WindowConstructionShadeAbridged(IDdEnergyBaseModel):
+    """Construction for window objects with an included shade layer."""
+
+    type: constr(regex='^WindowConstructionShadeAbridged$') = \
+        'WindowConstructionShadeAbridged'
+
+    window_construction: WindowConstructionAbridged = Field(
         ...,
-        description='List of strings for opaque material identifiers. The order '
-        'of the materials is from exterior to interior.',
-        min_items=1,
-        max_items=10
+        description='A WindowConstructionAbridged object that serves as the '
+        '"switched off" version of the construction (aka. the "bare construction"). '
+        'The shade_material and shade_location will be used to modify this '
+        'starting construction.'
     )
 
-
-class OpaqueConstruction(OpaqueConstructionAbridged):
-    """Construction for opaque objects (Face, Shade, Door)."""
-
-    type: constr(regex='^OpaqueConstruction$') = 'OpaqueConstruction'
-
-    materials: List[Union[EnergyMaterial, EnergyMaterialNoMass]] = Field(
+    shade_material: str = Field(
         ...,
-        description='List of opaque materials. The order of the materials is '
-        'from outside to inside.',
-        min_items=1,
-        max_items=10
+        min_length=1,
+        max_length=100,
+        description='Identifier of a An EnergyWindowMaterialShade or an '
+        'EnergyWindowMaterialBlind that serves as the shading layer for this '
+        'construction. This can also be an EnergyWindowMaterialGlazing, which '
+        'will indicate that the WindowConstruction has a dynamically-controlled '
+        'glass pane like an electrochromic window assembly.'
     )
+
+    shade_location: ShadeLocation = Field(
+        ShadeLocation.interior,
+        description='Text to indicate where in the window assembly the shade_material '
+        'is located.  Note that the WindowConstruction must have at least one gas '
+        'gap to use the "Between" option. Also note that, for a WindowConstruction '
+        'with more than one gas gap, the "Between" option defalts to using the '
+        'inner gap as this is the only option that EnergyPlus supports.'
+    )
+
+    control_type: ControlType = Field(
+        ControlType.always_on,
+        description='Text to indicate how the shading device is controlled, which '
+        'determines when the shading is “on” or “off.”'
+    )
+
+    setpoint: float = Field(
+        None,
+        description='A number that corresponds to the specified control_type. '
+        'This can be a value in (W/m2), (C) or (W) depending upon the control type.'
+        'Note that this value cannot be None for any control type except "AlwaysOn."'
+    )
+
+    schedule: str = Field(
+        None,
+        min_length=1,
+        max_length=100,
+        description='An optional schedule identifier to be applied on top of the '
+        'control_type. If None, the control_type will govern all behavior of '
+        'the construction.'
+    )
+
+    @root_validator
+    def check_setpoint_exists(cls, values):
+        "Ensure the setpoint exists if control_type isn't AlwaysOn."
+        control_type = values.get('control_type')
+        setpoint = values.get('setpoint')
+        if control_type != 'AlwaysOn':
+            assert setpoint is not None, 'Control setpoint cannot ' \
+                'be None for control type "{}"'.format(control_type)
+        return values
+
+    class Config:
+        @staticmethod
+        def schema_extra(schema, model):
+            schema['properties']['schedule']['anyOf'] = \
+                [
+                    {"$ref": "#/components/schemas/ScheduleRuleset"},
+                    {"$ref": "#/components/schemas/ScheduleFixedInterval"}
+            ]
+
+
+class WindowConstructionShade(WindowConstructionShadeAbridged):
+    """Construction for window objects (Aperture, Door)."""
+
+    type: constr(regex='^WindowConstructionShade$') = 'WindowConstructionShade'
+
+    window_construction: WindowConstruction = Field(
+        ...,
+        description='A WindowConstruction object that serves as the "switched off" '
+        'version of the construction (aka. the "bare construction"). '
+        'The shade_material and shade_location will be used to modify this '
+        'starting construction.'
+    )
+
+    shade_material: Union[
+        EnergyWindowMaterialShade, EnergyWindowMaterialBlind,
+        EnergyWindowMaterialGlazing
+    ] = Field(
+        ...,
+        description='Identifier of a An EnergyWindowMaterialShade or an '
+        'EnergyWindowMaterialBlind that serves as the shading layer for this '
+        'construction. This can also be an EnergyWindowMaterialGlazing, which '
+        'will indicate that the WindowConstruction has a dynamically-controlled '
+        'glass pane like an electrochromic window assembly.'
+    )
+
+    schedule: Union[ScheduleRuleset, ScheduleFixedInterval] = Field(
+        None,
+        description='An optional ScheduleRuleset or ScheduleFixedInterval to be '
+        'applied on top of the control_type. If None, the control_type will govern '
+        'all behavior of the construction.'
+    )
+
+    class Config:
+        @staticmethod
+        def schema_extra(schema, model):
+            schema['properties']['schedule']['anyOf'] = \
+                [
+                    {"$ref": "#/components/schemas/ScheduleRuleset"},
+                    {"$ref": "#/components/schemas/ScheduleFixedInterval"}
+            ]
 
 
 class ShadeConstruction(IDdEnergyBaseModel):
@@ -86,14 +225,14 @@ class ShadeConstruction(IDdEnergyBaseModel):
         0.2,
         ge=0,
         le=1,
-        description=' A number for the solar reflectance of the construction.'
+        description='A number for the solar reflectance of the construction.'
     )
 
     visible_reflectance: float = Field(
         0.2,
         ge=0,
         le=1,
-        description=' A number for the visible reflectance of the construction.'
+        description='A number for the visible reflectance of the construction.'
     )
 
     is_specular: bool = Field(

--- a/honeybee_schema/energy/properties.py
+++ b/honeybee_schema/energy/properties.py
@@ -6,7 +6,8 @@ from .._base import NoExtraBaseModel
 from .constructionset import ConstructionSetAbridged, ConstructionSet
 from .construction import OpaqueConstructionAbridged, WindowConstructionAbridged, \
     ShadeConstruction, AirBoundaryConstructionAbridged, OpaqueConstruction, \
-    WindowConstruction, AirBoundaryConstruction
+    WindowConstruction, AirBoundaryConstruction, WindowConstructionShadeAbridged, \
+    WindowConstructionShade
 from .material import EnergyMaterial, EnergyMaterialNoMass, \
     EnergyWindowMaterialGas, EnergyWindowMaterialGasCustom, \
     EnergyWindowMaterialGasMixture, EnergyWindowMaterialSimpleGlazSys, \
@@ -180,8 +181,9 @@ class ModelEnergyProperties(NoExtraBaseModel):
 
     constructions: List[Union[
         OpaqueConstructionAbridged, WindowConstructionAbridged,
-        ShadeConstruction, AirBoundaryConstructionAbridged,
-        OpaqueConstruction, WindowConstruction, AirBoundaryConstruction]] = Field(
+        WindowConstructionShadeAbridged, AirBoundaryConstructionAbridged,
+        OpaqueConstruction, WindowConstruction, WindowConstructionShade,
+        AirBoundaryConstruction, ShadeConstruction]] = Field(
         default=None,
         description='A list of all unique constructions in the model. This includes '
         'constructions across all Faces, Apertures, Doors, Shades, Room '

--- a/samples/construction/construction_window_shade.json
+++ b/samples/construction/construction_window_shade.json
@@ -10,7 +10,7 @@
             "Generic Clear Glass"
         ]
     },
-    "shade_material": "Plastic Blind",
+    "shade_material": "Low-e Diffusing Shade",
     "shade_location": "Interior",
     "control_type": "AlwaysOn"
 }

--- a/scripts/sample_construction.py
+++ b/scripts/sample_construction.py
@@ -2,9 +2,11 @@
 from __future__ import division
 
 from honeybee_energy.construction.window import WindowConstruction
-from honeybee_energy.material.shade import EnergyWindowMaterialBlind
+from honeybee_energy.construction.windowshade import WindowConstructionShade
+from honeybee_energy.material.shade import EnergyWindowMaterialBlind, \
+    EnergyWindowMaterialShade
 
-from  honeybee_energy.lib.materials import lowe_glass, clear_glass, argon_gap
+from honeybee_energy.lib.materials import lowe_glass, clear_glass, argon_gap
 from honeybee_energy.lib.constructions import generic_exterior_wall, \
     generic_roof, generic_exterior_door, generic_double_pane
 
@@ -45,12 +47,28 @@ def construction_window_triple(directory):
 
 
 def construction_window_blinds(directory):
-    blinds = EnergyWindowMaterialBlind('Generic Aluminium Blinds')
-    window_with_blinds = WindowConstruction(
-        'Triple Pane Argon', [lowe_glass, argon_gap, lowe_glass, blinds])
+    shade_mat = EnergyWindowMaterialBlind(
+        'Plastic Blind', 'Vertical', 0.025, 0.01875, 0.003, 90, 0.2, 0.05, 0.4,
+        0.05, 0.45, 0, 0.95, 0.1, 1)
+    window_constr = WindowConstruction('Double Low-E', [lowe_glass, argon_gap, clear_glass])
+    window_with_blinds = WindowConstructionShade(
+        'Double Low-E Outside Shade', window_constr, shade_mat, 'Interior')
     dest_file = os.path.join(directory, 'construction_window_blinds.json')
     with open(dest_file, 'w') as fp:
         json.dump(window_with_blinds.to_dict(abridged=True), fp, indent=4)
+
+
+def construction_window_shade(directory):
+    """Test the initialization of WindowConstructionShade objects with shades."""
+    shade_mat = EnergyWindowMaterialShade(
+        'Low-e Diffusing Shade', 0.025, 0.15, 0.5, 0.25, 0.5, 0, 0.4,
+        0.2, 0.1, 0.75, 0.25)
+    window_constr = WindowConstruction('Double Low-E', [lowe_glass, argon_gap, clear_glass])
+    window_with_shade = WindowConstructionShade(
+        'Double Low-E Outside Shade', window_constr, shade_mat, 'Interior')
+    dest_file = os.path.join(directory, 'construction_window_shade.json')
+    with open(dest_file, 'w') as fp:
+        json.dump(window_with_shade.to_dict(abridged=True), fp, indent=4)
 
 
 # run all functions within the file
@@ -63,3 +81,4 @@ construction_opaque_wall(sample_directory)
 construction_window_double(sample_directory)
 construction_window_triple(sample_directory)
 construction_window_blinds(sample_directory)
+construction_window_shade(sample_directory)

--- a/tests/test_construction.py
+++ b/tests/test_construction.py
@@ -1,5 +1,5 @@
 from honeybee_schema.energy.construction import OpaqueConstructionAbridged, \
-        WindowConstructionAbridged
+    WindowConstructionAbridged, WindowConstructionShadeAbridged
 from copy import copy
 from pydantic import ValidationError
 import pytest
@@ -21,11 +21,6 @@ def test_construction_window_triple():
     WindowConstructionAbridged.parse_file(file_path)
 
 
-def test_construction_window_blinds():
-    file_path = os.path.join(target_folder, 'construction_window_blinds.json')
-    WindowConstructionAbridged.parse_file(file_path)
-
-
 def test_construction_opaque_door():
     file_path = os.path.join(target_folder, 'construction_opaque_door.json')
     OpaqueConstructionAbridged.parse_file(file_path)
@@ -39,6 +34,16 @@ def test_construction_opaque_roof():
 def test_construction_opaque_wall():
     file_path = os.path.join(target_folder, 'construction_opaque_wall.json')
     OpaqueConstructionAbridged.parse_file(file_path)
+
+
+def test_construction_window_shade():
+    file_path = os.path.join(target_folder, 'construction_window_shade.json')
+    WindowConstructionShadeAbridged.parse_file(file_path)
+
+
+def test_construction_window_blinds():
+    file_path = os.path.join(target_folder, 'construction_window_blinds.json')
+    WindowConstructionShadeAbridged.parse_file(file_path)
 
 
 def test_length_opaque():


### PR DESCRIPTION
This PR is coordianted with [this one over on honeybee-energy](https://github.com/ladybug-tools/honeybee-energy/pull/211).  

It fixes the way that blinds and shades were represented in the schema previously, which could never be simulated by EnergyPlus since E+ always needs a ShadingControl object in order to be able to simulate them. So I added a new WindowConstructionShaded class to handle the creation of this ShadingControl object and allow users to change some of its properties.

@MingboPeng , I just requested you review here so that you are aware of the change.