### PR TITLE
feat(ventcool): Add objects for simple window-based ventilative cooling

### DIFF
--- a/honeybee_schema/energy/properties.py
+++ b/honeybee_schema/energy/properties.py
@@ -15,6 +15,7 @@ from .material import EnergyMaterial, EnergyMaterialNoMass, \
 from .programtype import ProgramTypeAbridged, ProgramType
 from .load import PeopleAbridged, LightingAbridged, ElectricEquipmentAbridged, \
     GasEquipmentAbridged, InfiltrationAbridged, VentilationAbridged, SetpointAbridged
+from .ventcool import VentilationControlAbridged, VentilationOpening
 from .schedule import ScheduleTypeLimit, ScheduleRulesetAbridged, \
     ScheduleFixedIntervalAbridged, ScheduleRuleset, ScheduleFixedInterval
 from .hvac import IdealAirSystemAbridged
@@ -62,6 +63,12 @@ class DoorEnergyPropertiesAbridged(NoExtraBaseModel):
         'global_construction_set.'
     )
 
+    vent_opening: VentilationOpening = Field(
+        default=None,
+        description='An optional VentilationOpening to specify the operable '
+        'portion of the Door.'
+    )
+
 
 class ApertureEnergyPropertiesAbridged(NoExtraBaseModel):
 
@@ -75,6 +82,12 @@ class ApertureEnergyPropertiesAbridged(NoExtraBaseModel):
         description='Identifier of a WindowConstruction for the aperture. If None, the '
         'construction is set by the parent Room construction_set or the Model '
         'global_construction_set.'
+    )
+
+    vent_opening: VentilationOpening = Field(
+        default=None,
+        description='An optional VentilationOpening to specify the operable '
+        'portion of the Aperture.'
     )
 
 
@@ -157,6 +170,12 @@ class RoomEnergyPropertiesAbridged(NoExtraBaseModel):
     setpoint: SetpointAbridged = Field(
         default=None,
         description='Setpoint object for the temperature setpoints of the Room.'
+    )
+
+    window_vent_control: VentilationControlAbridged = Field(
+        default=None,
+        description='An optional VentilationControl object to dictate the opening '
+        'of windows. If None, the windows will never open.'
     )
 
 

--- a/honeybee_schema/energy/ventcool.py
+++ b/honeybee_schema/energy/ventcool.py
@@ -1,0 +1,105 @@
+"""Programtype Schema"""
+from pydantic import Field, constr
+
+from .._base import NoExtraBaseModel
+
+
+class VentilationControlAbridged(NoExtraBaseModel):
+
+    type: constr(regex='^VentilationControlAbridged$') = 'VentilationControlAbridged'
+
+    min_indoor_temperature: float = Field(
+        -100,
+        ge=-100,
+        le=100,
+        description='A number for the minimum indoor temperature at which to '
+        'ventilate in Celsius. Typically, this variable is used to initiate ventilation.'
+    )
+
+    max_indoor_temperature: float = Field(
+        100,
+        ge=-100,
+        le=100,
+        description='A number for the maximum indoor temperature at which to '
+        'ventilate in Celsius. This can be used to set a maximum temperature at '
+        'which point ventilation is stopped and a cooling system is turned on.'
+    )
+
+    min_outdoor_temperature: float = Field(
+        -100,
+        ge=-100,
+        le=100,
+        description='A number for the minimum outdoor temperature at which to ventilate '
+        'in Celsius. This can be used to ensure ventilative cooling does not happen '
+        'during the winter even if the Room is above the min_indoor_temperature.'
+    )
+
+    max_outdoor_temperature: float = Field(
+        100,
+        ge=-100,
+        le=100,
+        description='A number for the maximum indoor temperature at which to ventilate '
+        'in Celsius. This can be used to set a limit for when it is considered too hot '
+        'outside for ventilative cooling.'
+    )
+
+    delta_temperature: float = Field(
+        -100,
+        ge=-100,
+        le=100,
+        description='A number for the temperature differential in Celsius between '
+        'indoor and outdoor below which ventilation is shut off.  This should usually '
+        'be a negative number so that ventilation only occurs when the outdoors is '
+        'cooler than the indoors. Positive numbers indicate how much hotter the '
+        'outdoors can be than the indoors before ventilation is stopped.'
+    )
+
+    schedule: str = Field(
+        default=None,
+        min_length=1,
+        max_length=100,
+        description='Identifier of the schedule for the ventilation over the course of '
+        'the year. Note that this is applied on top of any setpoints. The type of this '
+        'schedule should be On/Off and values should be either 0 (no possibility of '
+        'ventilation) or 1 (ventilation possible).'
+    )
+
+
+class VentilationOpening(NoExtraBaseModel):
+
+    type: constr(regex='^VentilationOpening$') = 'VentilationOpening'
+
+    fraction_area_operable: float = Field(
+        0.5,
+        ge=0,
+        le=1,
+        description='A number for the fraction of the window area that is operable.'
+    )
+
+    fraction_height_operable: float = Field(
+        1.0,
+        ge=0,
+        le=1,
+        description='A number for the fraction of the distance from the bottom of the '
+        'window to the top that is operable.'
+    )
+
+    discharge_coefficient: float = Field(
+        0.17,
+        ge=0,
+        le=1,
+        description='A number that will be multipled by the area of the window in the '
+        'stack (buoyancy-driven) part of the equation to account for additional '
+        'friction from window geometry, insect screens, etc. Typical values include '
+        '0.17, for unobstructed windows with insect screens and 0.25 for unobstructed '
+        'windows without insect screens. This value should be lowered if windows are '
+        'of an awning or casement type and not allowed to fully open.'
+    )
+
+    wind_cross_vent: bool = Field(
+        False,
+        description='Boolean to indicate if there is an opening of roughly equal area '
+        'on the opposite side of the Room such that wind-driven cross ventilation will '
+        'be induced. If False, the assumption is that the operable area is primarily on '
+        'one side of the Room and there is no wind-driven ventilation.'
+    )

--- a/samples/model/model_energy_window_ventilation.json
+++ b/samples/model/model_energy_window_ventilation.json
@@ -1,0 +1,526 @@
+{
+    "type": "Model",
+    "identifier": "TinyHouse",
+    "display_name": "TinyHouse",
+    "units": "Meters",
+    "properties": {
+        "type": "ModelProperties",
+        "energy": {
+            "type": "ModelEnergyProperties",
+            "construction_sets": [],
+            "constructions": [],
+            "materials": [],
+            "hvacs": [
+                {
+                    "type": "IdealAirSystemAbridged",
+                    "identifier": "TinyHouseZone_IdealAir",
+                    "economizer_type": "DifferentialDryBulb",
+                    "demand_controlled_ventilation": false,
+                    "sensible_heat_recovery": 0.0,
+                    "latent_heat_recovery": 0.0,
+                    "heating_air_temperature": 50.0,
+                    "cooling_air_temperature": 13.0,
+                    "heating_limit": {
+                        "type": "Autosize"
+                    },
+                    "cooling_limit": {
+                        "type": "Autosize"
+                    }
+                }
+            ],
+            "program_types": [],
+            "schedules": [
+                {
+                    "type": "ScheduleRulesetAbridged",
+                    "identifier": "House Heating",
+                    "day_schedules": [
+                        {
+                            "type": "ScheduleDay",
+                            "identifier": "House Heating_Day Schedule",
+                            "values": [
+                                20.0
+                            ],
+                            "times": [
+                                [
+                                    0,
+                                    0
+                                ]
+                            ],
+                            "interpolate": false
+                        }
+                    ],
+                    "default_day_schedule": "House Heating_Day Schedule",
+                    "schedule_type_limit": "Temperature"
+                },
+                {
+                    "type": "ScheduleRulesetAbridged",
+                    "identifier": "House Cooling",
+                    "day_schedules": [
+                        {
+                            "type": "ScheduleDay",
+                            "identifier": "House Cooling_Day Schedule",
+                            "values": [
+                                28.0
+                            ],
+                            "times": [
+                                [
+                                    0,
+                                    0
+                                ]
+                            ],
+                            "interpolate": false
+                        }
+                    ],
+                    "default_day_schedule": "House Cooling_Day Schedule",
+                    "schedule_type_limit": "Temperature"
+                },
+                {
+                    "type": "ScheduleRulesetAbridged",
+                    "identifier": "Always On",
+                    "day_schedules": [
+                        {
+                            "type": "ScheduleDay",
+                            "identifier": "Always On_Day Schedule",
+                            "values": [
+                                1.0
+                            ],
+                            "times": [
+                                [
+                                    0,
+                                    0
+                                ]
+                            ],
+                            "interpolate": false
+                        }
+                    ],
+                    "default_day_schedule": "Always On_Day Schedule",
+                    "schedule_type_limit": "Fractional"
+                }
+            ],
+            "schedule_type_limits": [
+                {
+                    "type": "ScheduleTypeLimit",
+                    "identifier": "Fractional",
+                    "lower_limit": 0.0,
+                    "upper_limit": 1.0,
+                    "numeric_type": "Continuous",
+                    "unit_type": "Dimensionless"
+                },
+                {
+                    "type": "ScheduleTypeLimit",
+                    "identifier": "Temperature",
+                    "lower_limit": -273.15,
+                    "upper_limit": {
+                        "type": "NoLimit"
+                    },
+                    "numeric_type": "Continuous",
+                    "unit_type": "Temperature"
+                }
+            ]
+        }
+    },
+    "rooms": [
+        {
+            "type": "Room",
+            "identifier": "TinyHouseZone",
+            "display_name": "TinyHouseZone",
+            "properties": {
+                "type": "RoomPropertiesAbridged",
+                "energy": {
+                    "type": "RoomEnergyPropertiesAbridged",
+                    "hvac": "TinyHouseZone_IdealAir",
+                    "setpoint": {
+                        "type": "SetpointAbridged",
+                        "identifier": "House Setpoint",
+                        "heating_schedule": "House Heating",
+                        "cooling_schedule": "House Cooling"
+                    },
+                    "window_vent_control": {
+                        "type": "VentilationControlAbridged",
+                        "min_indoor_temperature": 22.0,
+                        "max_indoor_temperature": 27.0,
+                        "min_outdoor_temperature": 12.0,
+                        "max_outdoor_temperature": 30.0,
+                        "delta_temperature": -100.0,
+                        "schedule": "Always On"
+                    }
+                }
+            },
+            "faces": [
+                {
+                    "type": "Face",
+                    "identifier": "TinyHouseZone_Bottom",
+                    "display_name": "TinyHouseZone_Bottom",
+                    "properties": {
+                        "type": "FacePropertiesAbridged",
+                        "energy": {
+                            "type": "FaceEnergyPropertiesAbridged"
+                        }
+                    },
+                    "geometry": {
+                        "type": "Face3D",
+                        "boundary": [
+                            [
+                                0.0,
+                                0.0,
+                                0.0
+                            ],
+                            [
+                                0.0,
+                                10.0,
+                                0.0
+                            ],
+                            [
+                                5.0,
+                                10.0,
+                                0.0
+                            ],
+                            [
+                                5.0,
+                                0.0,
+                                0.0
+                            ]
+                        ]
+                    },
+                    "face_type": "Floor",
+                    "boundary_condition": {
+                        "type": "Ground"
+                    }
+                },
+                {
+                    "type": "Face",
+                    "identifier": "TinyHouseZone_Front",
+                    "display_name": "TinyHouseZone_Front",
+                    "properties": {
+                        "type": "FacePropertiesAbridged",
+                        "energy": {
+                            "type": "FaceEnergyPropertiesAbridged"
+                        }
+                    },
+                    "geometry": {
+                        "type": "Face3D",
+                        "boundary": [
+                            [
+                                5.0,
+                                10.0,
+                                3.0
+                            ],
+                            [
+                                5.0,
+                                10.0,
+                                0.0
+                            ],
+                            [
+                                0.0,
+                                10.0,
+                                0.0
+                            ],
+                            [
+                                0.0,
+                                10.0,
+                                3.0
+                            ]
+                        ]
+                    },
+                    "face_type": "Wall",
+                    "boundary_condition": {
+                        "type": "Outdoors",
+                        "sun_exposure": true,
+                        "wind_exposure": true,
+                        "view_factor": {
+                            "type": "Autocalculate"
+                        }
+                    },
+                    "apertures": [
+                        {
+                            "type": "Aperture",
+                            "identifier": "TinyHouseZone_Front_Glz0",
+                            "display_name": "TinyHouseZone_Front_Glz0",
+                            "properties": {
+                                "type": "AperturePropertiesAbridged",
+                                "energy": {
+                                    "type": "ApertureEnergyPropertiesAbridged",
+                                    "vent_opening": {
+                                        "type": "VentilationOpening",
+                                        "fraction_area_operable": 0.5,
+                                        "fraction_height_operable": 1.0,
+                                        "discharge_coefficient": 0.17,
+                                        "wind_cross_vent": true
+                                    }
+                                }
+                            },
+                            "geometry": {
+                                "type": "Face3D",
+                                "boundary": [
+                                    [
+                                        4.08113883008419,
+                                        10.0,
+                                        2.448683298050514
+                                    ],
+                                    [
+                                        4.08113883008419,
+                                        10.0,
+                                        0.5513167019494862
+                                    ],
+                                    [
+                                        0.9188611699158102,
+                                        10.0,
+                                        0.5513167019494862
+                                    ],
+                                    [
+                                        0.9188611699158102,
+                                        10.0,
+                                        2.448683298050514
+                                    ]
+                                ]
+                            },
+                            "is_operable": true,
+                            "boundary_condition": {
+                                "type": "Outdoors",
+                                "sun_exposure": true,
+                                "wind_exposure": true,
+                                "view_factor": {
+                                    "type": "Autocalculate"
+                                }
+                            }
+                        }
+                    ]
+                },
+                {
+                    "type": "Face",
+                    "identifier": "TinyHouseZone_Right",
+                    "display_name": "TinyHouseZone_Right",
+                    "properties": {
+                        "type": "FacePropertiesAbridged",
+                        "energy": {
+                            "type": "FaceEnergyPropertiesAbridged"
+                        }
+                    },
+                    "geometry": {
+                        "type": "Face3D",
+                        "boundary": [
+                            [
+                                5.0,
+                                0.0,
+                                3.0
+                            ],
+                            [
+                                5.0,
+                                0.0,
+                                0.0
+                            ],
+                            [
+                                5.0,
+                                10.0,
+                                0.0
+                            ],
+                            [
+                                5.0,
+                                10.0,
+                                3.0
+                            ]
+                        ]
+                    },
+                    "face_type": "Wall",
+                    "boundary_condition": {
+                        "type": "Outdoors",
+                        "sun_exposure": true,
+                        "wind_exposure": true,
+                        "view_factor": {
+                            "type": "Autocalculate"
+                        }
+                    }
+                },
+                {
+                    "type": "Face",
+                    "identifier": "TinyHouseZone_Back",
+                    "display_name": "TinyHouseZone_Back",
+                    "properties": {
+                        "type": "FacePropertiesAbridged",
+                        "energy": {
+                            "type": "FaceEnergyPropertiesAbridged"
+                        }
+                    },
+                    "geometry": {
+                        "type": "Face3D",
+                        "boundary": [
+                            [
+                                0.0,
+                                0.0,
+                                3.0
+                            ],
+                            [
+                                0.0,
+                                0.0,
+                                0.0
+                            ],
+                            [
+                                5.0,
+                                0.0,
+                                0.0
+                            ],
+                            [
+                                5.0,
+                                0.0,
+                                3.0
+                            ]
+                        ]
+                    },
+                    "face_type": "Wall",
+                    "boundary_condition": {
+                        "type": "Outdoors",
+                        "sun_exposure": true,
+                        "wind_exposure": true,
+                        "view_factor": {
+                            "type": "Autocalculate"
+                        }
+                    },
+                    "apertures": [
+                        {
+                            "type": "Aperture",
+                            "identifier": "TinyHouseZone_Back_Glz0",
+                            "display_name": "TinyHouseZone_Back_Glz0",
+                            "properties": {
+                                "type": "AperturePropertiesAbridged",
+                                "energy": {
+                                    "type": "ApertureEnergyPropertiesAbridged",
+                                    "vent_opening": {
+                                        "type": "VentilationOpening",
+                                        "fraction_area_operable": 0.5,
+                                        "fraction_height_operable": 1.0,
+                                        "discharge_coefficient": 0.17,
+                                        "wind_cross_vent": true
+                                    }
+                                }
+                            },
+                            "geometry": {
+                                "type": "Face3D",
+                                "boundary": [
+                                    [
+                                        0.9188611699158102,
+                                        0.0,
+                                        2.448683298050514
+                                    ],
+                                    [
+                                        0.9188611699158102,
+                                        0.0,
+                                        0.5513167019494862
+                                    ],
+                                    [
+                                        4.08113883008419,
+                                        0.0,
+                                        0.5513167019494862
+                                    ],
+                                    [
+                                        4.08113883008419,
+                                        0.0,
+                                        2.448683298050514
+                                    ]
+                                ]
+                            },
+                            "is_operable": true,
+                            "boundary_condition": {
+                                "type": "Outdoors",
+                                "sun_exposure": true,
+                                "wind_exposure": true,
+                                "view_factor": {
+                                    "type": "Autocalculate"
+                                }
+                            }
+                        }
+                    ]
+                },
+                {
+                    "type": "Face",
+                    "identifier": "TinyHouseZone_Left",
+                    "display_name": "TinyHouseZone_Left",
+                    "properties": {
+                        "type": "FacePropertiesAbridged",
+                        "energy": {
+                            "type": "FaceEnergyPropertiesAbridged"
+                        }
+                    },
+                    "geometry": {
+                        "type": "Face3D",
+                        "boundary": [
+                            [
+                                0.0,
+                                10.0,
+                                3.0
+                            ],
+                            [
+                                0.0,
+                                10.0,
+                                0.0
+                            ],
+                            [
+                                0.0,
+                                0.0,
+                                0.0
+                            ],
+                            [
+                                0.0,
+                                0.0,
+                                3.0
+                            ]
+                        ]
+                    },
+                    "face_type": "Wall",
+                    "boundary_condition": {
+                        "type": "Outdoors",
+                        "sun_exposure": true,
+                        "wind_exposure": true,
+                        "view_factor": {
+                            "type": "Autocalculate"
+                        }
+                    }
+                },
+                {
+                    "type": "Face",
+                    "identifier": "TinyHouseZone_Top",
+                    "display_name": "TinyHouseZone_Top",
+                    "properties": {
+                        "type": "FacePropertiesAbridged",
+                        "energy": {
+                            "type": "FaceEnergyPropertiesAbridged"
+                        }
+                    },
+                    "geometry": {
+                        "type": "Face3D",
+                        "boundary": [
+                            [
+                                5.0,
+                                0.0,
+                                3.0
+                            ],
+                            [
+                                5.0,
+                                10.0,
+                                3.0
+                            ],
+                            [
+                                0.0,
+                                10.0,
+                                3.0
+                            ],
+                            [
+                                0.0,
+                                0.0,
+                                3.0
+                            ]
+                        ]
+                    },
+                    "face_type": "RoofCeiling",
+                    "boundary_condition": {
+                        "type": "Outdoors",
+                        "sun_exposure": true,
+                        "wind_exposure": true,
+                        "view_factor": {
+                            "type": "Autocalculate"
+                        }
+                    }
+                }
+            ]
+        }
+    ]
+}

--- a/samples/ventcool/ventilation_control_detailed.json
+++ b/samples/ventcool/ventilation_control_detailed.json
@@ -1,0 +1,9 @@
+{
+    "type": "VentilationControlAbridged",
+    "min_indoor_temperature": 22.0,
+    "max_indoor_temperature": 28.0,
+    "min_outdoor_temperature": 12.0,
+    "max_outdoor_temperature": 32.0,
+    "delta_temperature": 0.0,
+    "schedule": "Night Flush Schedule"
+}

--- a/samples/ventcool/ventilation_control_simple.json
+++ b/samples/ventcool/ventilation_control_simple.json
@@ -1,0 +1,9 @@
+{
+    "type": "VentilationControlAbridged",
+    "min_indoor_temperature": 22.0,
+    "max_indoor_temperature": 100.0,
+    "min_outdoor_temperature": -100.0,
+    "max_outdoor_temperature": 100.0,
+    "delta_temperature": -100.0,
+    "schedule": "Always On"
+}

--- a/samples/ventcool/ventilation_opening_default.json
+++ b/samples/ventcool/ventilation_opening_default.json
@@ -1,0 +1,7 @@
+{
+    "type": "VentilationOpening",
+    "fraction_area_operable": 0.5,
+    "fraction_height_operable": 1.0,
+    "discharge_coefficient": 0.17,
+    "wind_cross_vent": false
+}

--- a/scripts/sample_hvac.py
+++ b/scripts/sample_hvac.py
@@ -19,7 +19,7 @@ def ideal_air_default(directory):
 
 def ideal_air_detailed(directory):
     ideal_air = IdealAirSystem('Passive House HVAC System')
-    
+
     ideal_air.economizer_type = 'DifferentialEnthalpy'
     ideal_air.demand_controlled_ventilation = True
     ideal_air.sensible_heat_recovery = 0.75

--- a/scripts/sample_ventcool.py
+++ b/scripts/sample_ventcool.py
@@ -1,0 +1,48 @@
+# coding=utf-8
+from honeybee_energy.ventcool.opening import VentilationOpening
+from honeybee_energy.ventcool.control import VentilationControl
+from honeybee_energy.schedule.day import ScheduleDay
+from honeybee_energy.schedule.ruleset import ScheduleRuleset
+import honeybee_energy.lib.scheduletypelimits as schedule_types
+
+from ladybug.dt import Time
+
+import os
+import json
+
+
+def ventilation_opening_default(directory):
+    ventilation = VentilationOpening()
+    dest_file = os.path.join(directory, 'ventilation_opening_default.json')
+    with open(dest_file, 'w') as fp:
+        json.dump(ventilation.to_dict(), fp, indent=4)
+
+
+def ventilation_control_simple(directory):
+    ventilation = VentilationControl(22)
+
+    dest_file = os.path.join(directory, 'ventilation_control_simple.json')
+    with open(dest_file, 'w') as fp:
+        json.dump(ventilation.to_dict(abridged=True), fp, indent=4)
+
+
+def ventilation_control_detailed(directory):
+    simple_flush = ScheduleDay('Simple Flush', [1, 0, 1],
+                               [Time(0, 0), Time(9, 0), Time(22, 0)])
+    schedule = ScheduleRuleset('Night Flush Schedule', simple_flush,
+                               None, schedule_types.fractional)
+    ventilation = VentilationControl(22, 28, 12, 32, 0)
+    ventilation.schedule = schedule
+
+    dest_file = os.path.join(directory, 'ventilation_control_detailed.json')
+    with open(dest_file, 'w') as fp:
+        json.dump(ventilation.to_dict(abridged=True), fp, indent=4)
+
+
+# run all functions within the file
+master_dir = os.path.split(os.path.dirname(__file__))[0]
+sample_directory = os.path.join(master_dir, 'samples', 'ventcool')
+
+ventilation_opening_default(sample_directory)
+ventilation_control_simple(sample_directory)
+ventilation_control_detailed(sample_directory)

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -9,65 +9,70 @@ target_folder_large = os.path.join(root, 'samples', 'model_large')
 
 
 def test_model_complete_multi_zone_office():
-    file_path  = os.path.join(target_folder, 'model_complete_multi_zone_office.json')
+    file_path = os.path.join(target_folder, 'model_complete_multi_zone_office.json')
     Model.parse_file(file_path)
 
 
 def test_model_complete_multiroom_radiance():
-    file_path  = os.path.join(target_folder, 'model_complete_multiroom_radiance.json')
-    Model.parse_file(file_path) 
+    file_path = os.path.join(target_folder, 'model_complete_multiroom_radiance.json')
+    Model.parse_file(file_path)
 
 
 def test_model_complete_single_zone_office():
-    file_path  = os.path.join(target_folder, 'model_complete_single_zone_office.json')
+    file_path = os.path.join(target_folder, 'model_complete_single_zone_office.json')
     Model.parse_file(file_path)
 
 
 def test_model_complete_user_data():
-    file_path  = os.path.join(target_folder, 'model_complete_user_data.json')
+    file_path = os.path.join(target_folder, 'model_complete_user_data.json')
     Model.parse_file(file_path)
 
 
 def test_model_complete_patient_room():
-    file_path  = os.path.join(target_folder, 'model_complete_patient_room.json')
-    Model.parse_file(file_path) 
+    file_path = os.path.join(target_folder, 'model_complete_patient_room.json')
+    Model.parse_file(file_path)
 
 
 def test_model_energy_shoe_box():
-    file_path  = os.path.join(target_folder, 'model_energy_shoe_box.json')
+    file_path = os.path.join(target_folder, 'model_energy_shoe_box.json')
     Model.parse_file(file_path)
 
 
 def test_model_energy_detailed_loads():
-    file_path  = os.path.join(target_folder, 'model_energy_detailed_loads.json')
-    Model.parse_file(file_path) 
+    file_path = os.path.join(target_folder, 'model_energy_detailed_loads.json')
+    Model.parse_file(file_path)
 
 
 def test_model_energy_fixed_interval():
-    file_path  = os.path.join(target_folder, 'model_energy_fixed_interval.json')
+    file_path = os.path.join(target_folder, 'model_energy_fixed_interval.json')
     Model.parse_file(file_path)
 
 
 def test_model_energy_no_program():
-    file_path  = os.path.join(target_folder, 'model_energy_no_program.json')
+    file_path = os.path.join(target_folder, 'model_energy_no_program.json')
+    Model.parse_file(file_path)
+
+
+def test_model_energy_window_ventilation():
+    file_path = os.path.join(target_folder, 'model_energy_window_ventilation.json')
     Model.parse_file(file_path)
 
 
 def test_model_5vertex_sub_faces():
-    file_path  = os.path.join(target_folder, 'model_5vertex_sub_faces.json')
+    file_path = os.path.join(target_folder, 'model_5vertex_sub_faces.json')
     Model.parse_file(file_path)
 
 
 def test_model_energy_properties_office():
-    file_path  = os.path.join(target_folder, 'model_energy_properties_office.json')
+    file_path = os.path.join(target_folder, 'model_energy_properties_office.json')
     ModelEnergyProperties.parse_file(file_path)
 
 
 def test_model_large_single_family_home():
-    file_path  = os.path.join(target_folder_large, 'single_family_home.json')
+    file_path = os.path.join(target_folder_large, 'single_family_home.json')
     Model.parse_file(file_path)
 
 
 def test_model_large_lab_building():
-    file_path  = os.path.join(target_folder_large, 'lab_building.json')
+    file_path = os.path.join(target_folder_large, 'lab_building.json')
     Model.parse_file(file_path)

--- a/tests/test_ventcool.py
+++ b/tests/test_ventcool.py
@@ -1,0 +1,20 @@
+from honeybee_schema.energy.ventcool import VentilationControlAbridged, VentilationOpening
+import os
+
+# target folder where all of the samples live
+root = os.path.dirname(os.path.dirname(__file__))
+target_folder = os.path.join(root, 'samples', 'ventcool')
+
+
+def test_ventilation_opening_default():
+    file_path = os.path.join(target_folder, 'ventilation_opening_default.json')
+    VentilationOpening.parse_file(file_path)
+
+
+def test_ventilation_control_simple():
+    file_path = os.path.join(target_folder, 'ventilation_control_simple.json')
+    VentilationControlAbridged.parse_file(file_path)
+
+def test_ventilation_control_detailed():
+    file_path = os.path.join(target_folder, 'ventilation_control_detailed.json')
+    VentilationControlAbridged.parse_file(file_path)


### PR DESCRIPTION
This commit adds objects for simple window-based ventilative cooling. While this commit only includes enough objects to model windows with ZoneVentilation:WindandStackOpenArea objects, many of these objects should also be used in the future AFN.

@mostaphaRoudsari , if you get the chance, please let me know if you have any comments on the vocabulary / terminology that I'm using here for the objects.

@saeranv , feel free to ask any questions that relate to your work as review comments.