### PR TITLE
ci(travis): put redoc-cli back

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,6 +34,7 @@ jobs:
     install:
     - pip install -r dev-requirements.txt
     - pip install -r requirements.txt
+    - npm install -g redoc-cli
     script:
     - export CLEAN_TAG=$(echo $TRAVIS_TAG | sed 's/v//g')
     - python docs.py --version $CLEAN_TAG


### PR DESCRIPTION
The current build for docs was failing since the line for installing redoc-cli has been removed here: https://github.com/ladybug-tools/honeybee-schema/commit/37b84fff45b5d0ab6666df8e1f81c03607a5234e