### PR TITLE
feat(ventcool): Add AFN objects to VentCool.

### DIFF
--- a/honeybee_schema/energy/properties.py
+++ b/honeybee_schema/energy/properties.py
@@ -15,7 +15,8 @@ from .material import EnergyMaterial, EnergyMaterialNoMass, \
 from .programtype import ProgramTypeAbridged, ProgramType
 from .load import PeopleAbridged, LightingAbridged, ElectricEquipmentAbridged, \
     GasEquipmentAbridged, InfiltrationAbridged, VentilationAbridged, SetpointAbridged
-from .ventcool import VentilationControlAbridged, VentilationOpening
+from .ventcool import VentilationControlAbridged, VentilationOpening, \
+    AFNSimulationControl, AFNReferenceCrack, AFNCrack
 from .schedule import ScheduleTypeLimit, ScheduleRulesetAbridged, \
     ScheduleFixedIntervalAbridged, ScheduleRuleset, ScheduleFixedInterval
 from .hvac.idealair import IdealAirSystemAbridged
@@ -107,6 +108,14 @@ class FaceEnergyPropertiesAbridged(NoExtraBaseModel):
         description='Identifier of an OpaqueConstruction for the Face. If None, the '
         'construction is set by the parent Room construction_set or the '
         'Model global_construction_set.'
+    )
+
+    # TODO: Figure out how to convert ZoneInfiltration into crack parameters and
+    # eliminate this property.
+    vent_crack: AFNCrack = Field(
+        default=None,
+        description='An optional AFNCrack to specify airflow through a surface crack '
+        'used by the AirflowNetwork.'
     )
 
 
@@ -238,3 +247,16 @@ class ModelEnergyProperties(NoExtraBaseModel):
         description='A list of all unique ScheduleTypeLimits in the model. This '
         'all ScheduleTypeLimits needed to make the Model schedules.'
     )
+
+    afn_simulation_control: AFNSimulationControl = Field(
+        default=None,
+        description='An optional parameter to define the global parameters for '
+        'an Airflow Network simulation.'
+    )
+
+    afn_reference_crack: AFNReferenceCrack = Field(
+        default=None,
+        description='An optional parameter to define the reference measurement '
+        'conditions under which the surface crack data was obtained.'
+    )
+

--- a/honeybee_schema/energy/properties.py
+++ b/honeybee_schema/energy/properties.py
@@ -16,7 +16,7 @@ from .programtype import ProgramTypeAbridged, ProgramType
 from .load import PeopleAbridged, LightingAbridged, ElectricEquipmentAbridged, \
     GasEquipmentAbridged, InfiltrationAbridged, VentilationAbridged, SetpointAbridged
 from .ventcool import VentilationControlAbridged, VentilationOpening, \
-    AFNSimulationControl, AFNReferenceCrack, AFNCrack
+    VentilationSimulationControl, AFNCrack
 from .schedule import ScheduleTypeLimit, ScheduleRulesetAbridged, \
     ScheduleFixedIntervalAbridged, ScheduleRuleset, ScheduleFixedInterval
 from .hvac.idealair import IdealAirSystemAbridged
@@ -110,12 +110,13 @@ class FaceEnergyPropertiesAbridged(NoExtraBaseModel):
         'Model global_construction_set.'
     )
 
-    # TODO: Figure out how to convert ZoneInfiltration into crack parameters and
-    # eliminate this property.
     vent_crack: AFNCrack = Field(
         default=None,
         description='An optional AFNCrack to specify airflow through a surface crack '
-        'used by the AirflowNetwork.'
+        'used by the AirflowNetwork. If this value is None and one of the '
+        'AirflowNetwork options are selected in the VentilationSimulationControl '
+        'object, a default value will be calculated to produce air flow leakages '
+        'equivalent to the zone flow rate defined by the corresponding Infiltration object.'
     )
 
 
@@ -248,15 +249,8 @@ class ModelEnergyProperties(NoExtraBaseModel):
         'all ScheduleTypeLimits needed to make the Model schedules.'
     )
 
-    afn_simulation_control: AFNSimulationControl = Field(
+    ventilation_simulation_control: VentilationSimulationControl = Field(
         default=None,
         description='An optional parameter to define the global parameters for '
-        'an Airflow Network simulation.'
+        'a ventilation cooling.'
     )
-
-    afn_reference_crack: AFNReferenceCrack = Field(
-        default=None,
-        description='An optional parameter to define the reference measurement '
-        'conditions under which the surface crack data was obtained.'
-    )
-

--- a/honeybee_schema/energy/properties.py
+++ b/honeybee_schema/energy/properties.py
@@ -113,10 +113,7 @@ class FaceEnergyPropertiesAbridged(NoExtraBaseModel):
     vent_crack: AFNCrack = Field(
         default=None,
         description='An optional AFNCrack to specify airflow through a surface crack '
-        'used by the AirflowNetwork. If this value is None and one of the '
-        'AirflowNetwork options are selected in the VentilationSimulationControl '
-        'object, a default value will be calculated to produce air flow leakages '
-        'equivalent to the zone flow rate defined by the corresponding Infiltration object.'
+        'used by the AirflowNetwork.'
     )
 
 

--- a/honeybee_schema/energy/ventcool.py
+++ b/honeybee_schema/energy/ventcool.py
@@ -105,9 +105,9 @@ class VentilationOpening(NoExtraBaseModel):
         'one side of the Room and there is no wind-driven ventilation.'
     )
 
-    air_mass_flow_coefficient_closed: float = Field(
+    flow_coefficient_closed: float = Field(
         default=None,
-        gt=0,
+        ge=0,
         description='An optional number in kg/s-m, at 1 Pa per meter of crack length, '
         'used to calculate the mass flow rate when the opening is closed; required to '
         'run an AirflowNetwork simulation. The DesignBuilder Cracks template defines '
@@ -116,7 +116,7 @@ class VentilationOpening(NoExtraBaseModel):
         'external window to be 0.003.'
     )
 
-    air_mass_flow_exponent_closed: float = Field(
+    flow_exponent_closed: float = Field(
         default=0.65,
         ge=0.5,
         le=1,
@@ -133,9 +133,12 @@ class VentilationOpening(NoExtraBaseModel):
         default=0.0001,
         gt=0,
         description='A number in kg/m3 indicating the minimum density difference above '
-        'which two-way flow may occur due to stack effect; required to run an '
-        'AirflowNetwork simulation. The default of 0.0001 is a typical default'
-        'value used for AirflowNetwork openings.'
+        'which two-way flow may occur due to stack effect, required to run an '
+        'AirflowNetwork simulation. This value is required because the air density '
+        'difference between two zones (which drives two-way air flow) will tend '
+        'towards division by zero errors as the air density difference approaches '
+        'zero. The default of 0.0001 is a typical default value used for AirflowNetwork '
+        'openings.'
     )
 
 
@@ -144,7 +147,7 @@ class AFNCrack(NoExtraBaseModel):
 
     type: constr(regex='^VentilationCrack$') = 'VentilationCrack'
 
-    air_mass_flow_coefficient_reference: float = Field(
+    flow_coefficient: float = Field(
         ...,
         gt=0,
         description='A number in kg/s-m at 1 Pa per meter of crack length at the '
@@ -156,7 +159,7 @@ class AFNCrack(NoExtraBaseModel):
         'constructions, respectively.'
     )
 
-    air_mass_flow_exponent: float = Field(
+    flow_exponent: float = Field(
         default=0.65,
         ge=0.5,
         le=1,
@@ -167,18 +170,6 @@ class AFNCrack(NoExtraBaseModel):
         'generally corresponding to laminar flow. The default of 0.65 is '
         'representative of many cases of wall and window leakage, used when the '
         'exponent cannot be measured.'
-    )
-
-    crack_factor: float = Field(
-        default=1,
-        gt=0,
-        le=1,
-        description='A numerical multiplier for air mass flow through a crack. '
-            'While the air_mass_flow_coefficient_reference and air_mass_flow_exponent '
-            'parameters describe crack geometry and orifice sharpness, this value '
-            'reflects linear reduction in flow rate due to equivalant area reduction, '
-            'similar to how the fraction_area_operable parameter is used in the '
-            'VentilationOpening object.'
     )
 
 
@@ -212,12 +203,13 @@ class VentilationSimulationControl(NoExtraBaseModel):
 
     reference_temperature: float = Field(
         default=20,
+        ge=-273.15,
         description='Reference temperature measurement in Celsius under which the '
         'surface crack data were obtained.'
     )
 
-    reference_barometric_pressure: float = Field(
-        default=101320,
+    reference_pressure: float = Field(
+        default=101325,
         ge=31000,
         le=120000,
         description='Reference barometric pressure measurement in Pascals under which '

--- a/honeybee_schema/energy/ventcool.py
+++ b/honeybee_schema/energy/ventcool.py
@@ -108,28 +108,25 @@ class VentilationOpening(NoExtraBaseModel):
     air_mass_flow_coefficient_closed: float = Field(
         default=None,
         gt=0,
-        description='A number in kg/s-m, at 1 Pa per meter of crack length, used to '
-        'calculate the mass flow rate when the opening is closed; required to run an '
-        'AirflowNetwork simulation. The DesignBuilder Cracks template defines the flow '
-        'coefficient for a tight, low-leakage closed external window to be 0.00001, and '
-        'the flow coefficient for a very poor, high-leakage closed external window to be '
-        '0.003. If this value is None and one of the AirflowNetwork options are selected '
-        'in the VentilationSimulationControl object, a default value will be calculated to '
-        'produce air flow leakages equivalent to the  zone flow rate defined by the '
-        'corresponding Infiltration object.'
+        description='An optional number in kg/s-m, at 1 Pa per meter of crack length, '
+        'used to calculate the mass flow rate when the opening is closed; required to '
+        'run an AirflowNetwork simulation. The DesignBuilder Cracks template defines '
+        'the flow coefficient for a tight, low-leakage closed external window to be '
+        '0.00001, and the flow coefficient for a very poor, high-leakage closed '
+        'external window to be 0.003.'
     )
 
     air_mass_flow_exponent_closed: float = Field(
-        default=0.7,
+        default=0.65,
         ge=0.5,
         le=1,
         description='An optional dimensionless number between 0.5 and 1 used to '
         'calculate the mass flow rate when the opening is closed; required to run an '
         'AirflowNetwork simulation. This value represents the leak geometry impact '
         'on airflow, with 0.5 generally corresponding to turbulent orifice flow and 1 '
-        'generally corresponding to laminar flow. The default of 0.7 is representative '
-        'of internal and external window leakage, according to the DesignBuilder Cracks '
-        'template.'
+        'generally corresponding to laminar flow. The default of 0.65 is '
+        'representative of many cases of wall and window leakage, used when the '
+        'exponent cannot be measured.'
     )
 
     minimum_density_difference_two_way: float = Field(
@@ -176,7 +173,12 @@ class AFNCrack(NoExtraBaseModel):
         default=1,
         gt=0,
         le=1,
-        description='A number indicating multiplier for air mass flow through a crack.'
+        description='A numerical multiplier for air mass flow through a crack. '
+            'While the air_mass_flow_coefficient_reference and air_mass_flow_exponent '
+            'parameters describe crack geometry and orifice sharpness, this value '
+            'reflects linear reduction in flow rate due to equivalant area reduction, '
+            'similar to how the fraction_area_operable parameter is used in the '
+            'VentilationOpening object.'
     )
 
 
@@ -184,8 +186,6 @@ class VentilationControlType(str, Enum):
     single_zone = 'SingleZone'
     multi_zone_with_distribution = 'MultiZoneWithDistribution'
     multi_zone_without_distribution = 'MultiZoneWithoutDistribution'
-    multi_zone_with_distribution_only_during_fan_operation = \
-        'MultiZoneWithDistributionOnlyDuringFanOperation'
 
 
 class BuildingType(str, Enum):
@@ -201,13 +201,13 @@ class VentilationSimulationControl(NoExtraBaseModel):
     vent_control_type: VentilationControlType = Field(
         default=VentilationControlType.single_zone,
         description='Text indicating type of ventilation control. Choices are: '
-        'SingleZone, MultiZoneWithDistribution, MultiZoneWithoutDistribution, or '
-        'MultiZoneWithDistributionOnlyDuringFanOperation. The MultiZone '
-        'options will model air flow with the AirflowNetwork model, which '
-        'is generally more accurate then the SingleZone option, but '
-        'requires defining more ventilation parameters to explicitly account '
-        'for weather and building-induced pressure differences, and the leakage '
-        'geometry corresponding to specific windows, doors, and surface cracks.'
+        'SingleZone, MultiZoneWithDistribution, MultiZoneWithoutDistribution. The '
+        'MultiZone options will model air flow with the AirflowNetwork model, which '
+        'is generally more accurate then the SingleZone option, but will take '
+        'considerably longer to simulate, and requires defining more ventilation '
+        'parameters to explicitly account for weather and building-induced pressure '
+        'differences, and the leakage geometry corresponding to specific windows, '
+        'doors, and surface cracks.'
     )
 
     reference_temperature: float = Field(

--- a/honeybee_schema/energy/ventcool.py
+++ b/honeybee_schema/energy/ventcool.py
@@ -66,11 +66,6 @@ class VentilationControlAbridged(NoExtraBaseModel):
     )
 
 
-class VerticalOpeningType(str, Enum):
-    non_pivoted = 'NonPivoted'
-    horizontally_pivoted = 'HorizontallyPivoted'
-
-
 class VentilationOpening(NoExtraBaseModel):
 
     type: constr(regex='^VentilationOpening$') = 'VentilationOpening'
@@ -80,8 +75,7 @@ class VentilationOpening(NoExtraBaseModel):
         ge=0,
         le=1,
         description='A number for the fraction of the window area that is operable.'
-        'If this ventilation opening is a crack, this value represents a multiplier'
-        'for crack airflow. Default: 0.5.'
+        'Default: 0.5.'
     )
 
     fraction_height_operable: float = Field(
@@ -112,14 +106,13 @@ class VentilationOpening(NoExtraBaseModel):
         'one side of the Room and there is no wind-driven ventilation. Default: False.'
     )
 
-    # TODO: AFN requirements
     air_mass_flow_coefficient_closed: float = Field(
         default=None,
         gt=0,
-        description='A number in kg/s-m used to calculate the mass '
-        'flow rate (air_mass_flow_coefficient * dP^air_mass_flow_exponent) when the '
-        'opening is closed, defined at 1 Pa per meter of crack length. This property is '
-        'only required if running an AirflowNetwork simulation.'
+        description='A number in kg/s-m used to calculate the mass flow rate '
+        '(air_mass_flow_coefficient * dP^air_mass_flow_exponent) when the opening is '
+        'closed, defined at 1 Pa per meter of crack length. This property is only '
+        'required if running an AirflowNetwork simulation.'
     )
 
     air_mass_flow_exponent_closed: float = Field(
@@ -132,24 +125,44 @@ class VentilationOpening(NoExtraBaseModel):
         'Default: 0.65.'
     )
 
-    vertical_opening_type: VerticalOpeningType = Field(
-        default=VerticalOpeningType.non_pivoted,
-        description='Text representing type of vertical opening. Choices are: '
-        'NonPivoted or HorizontallyPivoted. Default: NonPivoted.'
-    )
-
-    extra_opening_length: float = Field(
-        default=0,
-        ge=0,
-        description='Optional number in meters associated with extra crack length or '
-        'height of pivot axis of the vertical opening. The former is associated with '
-        'a NonPivoted vertical_opening_type referencing multiple openable parts. The '
-        'latter is associated with a HorizontallyPivoted vertical_opening_type '
-        'referencing the height of pivot axis. Default: 0.'
+    minimum_density_difference_two_way_flow: float = Field(
+        default=None,
+        gt=0,
+        description='Number indicating the minimum density difference above which '
+        'two-way flow may occur due to stack effect.'
     )
 
 
-class AFNControl(str, Enum):
+class AFNCrack(NoExtraBaseModel):
+    """Properties for airflow through a crack."""
+
+    type: constr(regex='^AFNCrack$') = 'AFNCrack'
+
+    air_mass_flow_coefficient_reference: float = Field(
+        ...,
+        gt=0,
+        description='The air mass flow coefficient in kg/s at the conditions defined in '
+        'the AFNReferenceCrack condition, defined at a 1 Pa difference across this '
+        'crack.'
+    )
+
+    air_mass_flow_exponent: float = Field(
+        default=0.65,
+        ge=0.5,
+        le=1,
+        description='The air mass flow exponent for the surface crack. Default: 0.65.'
+    )
+
+    crack_factor: float = Field(
+        default=1,
+        gt=0,
+        le=1,
+        description='A number indicating multiplier for air mass flow through a crack.'
+        'Default: 1.'
+    )
+
+
+class AFNControlType(str, Enum):
     multizone_with_distribution = 'MultiZoneWithDistribution'
     multizone_without_distribution = 'MultiZoneWithoutDistribution'
     multizone_with_distribution_only_during_fan_operation = \
@@ -166,20 +179,13 @@ class AFNSimulationControl(NoExtraBaseModel):
 
     type: constr(regex='^AFNSimulationControl$') = 'AFNSimulationControl'
 
-    afn_control: AFNControl = Field(
-        default=AFNControl.multizone_without_distribution,
+    afn_control_type: AFNControlType = Field(
+        default=AFNControlType.multizone_without_distribution,
         description='Text indicating type of control for an Airflow Network simulation. '
         'Choices are: MultiZoneWithDistribution, MultiZoneWithoutDistribution, '
         'or MultiZoneWithDistributionOnlyDuringFanOperation.'
     )
 
-    # TODO: Discussion required: We could calculate these geometric properties from the
-    # model itself however, it will require deriving the oriented bounding box, which I
-    # believe is a geometric method we don't have yet, so until then we may need to have
-    # this option to enter it manually.
-    # I can also easily write up a oriented bbox/ long/short axis method and get rid of this.
-    # Also note that non-rectangular footprints will require manually inputting the wind
-    # pressure coefficients, which is why we are using the rectangular assumption.
     building_type: AFNBuildingType = Field(
         default=AFNBuildingType.lowrise,
         description='Text indicating relationship between building footprint and '
@@ -208,7 +214,7 @@ class AFNSimulationControl(NoExtraBaseModel):
 
 
 class AFNReferenceCrack(NoExtraBaseModel):
-    """Measurement conditions for air mass flow coefficients used in Airflow Network."""
+    """Measurement conditions for air mass flow coefficients used by surface cracks."""
 
     type: constr(regex='^AFNReferenceCrack$') = 'AFNReferenceCrack'
 
@@ -234,40 +240,9 @@ class AFNReferenceCrack(NoExtraBaseModel):
     )
 
 
-class AFNCrack(NoExtraBaseModel):
-    """Properties for airflow through a crack."""
-
-    # TODO: Add reference to Surface to take a ventilation crack reference.
-
-    type: constr(regex='^AFNCrack$') = 'AFNCrack'
-
-    air_mass_flow_coefficient_reference: float = Field(
-        ...,
-        gt=0,
-        description='The air mass flow coefficient in kg/s at the conditions defined in '
-        'the AFNReferenceCrack conditions, defined at a 1 Pa difference across this '
-        'crack.'
-    )
-
-    air_mass_flow_exponent: float = Field(
-        default=0.65,
-        ge=0.5,
-        le=1,
-        description='The air mass flow exponent for the surface crack. Default: 0.65.'
-    )
-
-# TODO: Discussion: EMS:Sensor, EMS:Actuator, EMS:ProgramCallingManager, EMS:Program
-# is required for our implementation of the AFN, but is not referenced explicitly
-# since it links existing objects together.
-
-# TODO: The Ventilation Control Mode will be set to NoVent so it can be controlled with the
-# EMS. If other options (i.e Adaptive Comfort) is desired, we will need to add a lot of extra
-# parameters in the ventilation Control Objective which we are trying to avoid.
-
 if __name__ == '__main__':
-    print(AFNRoomAbridged.schema_json(indent=2))
-    print(AFNRoom.schema_json(indent=2))
-    print(AFNOpeningAbridged.schema_json(indent=2))
-    print(AFNOpening.schema_json(indent=2))
-    print(AFNReferenceCrack.schema_json(indent=2))
+    print(VentilationControlAbridged.schema_json(indent=2))
+    print(VentilationOpening.schema_json(indent=2))
     print(AFNSimulationControl.schema_json(indent=2))
+    print(AFNReferenceCrack.schema_json(indent=2))
+    print(AFNCrack.schema_json(indent=2))

--- a/honeybee_schema/energy/ventcool.py
+++ b/honeybee_schema/energy/ventcool.py
@@ -129,7 +129,7 @@ class VentilationOpening(NoExtraBaseModel):
         'exponent cannot be measured.'
     )
 
-    minimum_density_difference_two_way: float = Field(
+    two_way_threshold: float = Field(
         default=0.0001,
         gt=0,
         description='A number in kg/m3 indicating the minimum density difference above '
@@ -145,7 +145,7 @@ class VentilationOpening(NoExtraBaseModel):
 class AFNCrack(NoExtraBaseModel):
     """Properties for airflow through a crack."""
 
-    type: constr(regex='^VentilationCrack$') = 'VentilationCrack'
+    type: constr(regex='^AFNCrack$') = 'AFNCrack'
 
     flow_coefficient: float = Field(
         ...,

--- a/samples/model/model_energy_afn.json
+++ b/samples/model/model_energy_afn.json
@@ -1,0 +1,2010 @@
+{
+    "type": "Model",
+    "identifier": "Two_Zone_Simple",
+    "display_name": "Two_Zone_Simple",
+    "units": "Meters",
+    "properties": {
+        "type": "ModelProperties",
+        "energy": {
+            "type": "ModelEnergyProperties",
+            "construction_sets": [],
+            "constructions": [],
+            "materials": [],
+            "hvacs": [],
+            "program_types": [
+                {
+                    "type": "ProgramTypeAbridged",
+                    "identifier": "Generic Office Program",
+                    "people": {
+                        "type": "PeopleAbridged",
+                        "identifier": "Generic Office People",
+                        "people_per_area": 0.0565,
+                        "radiant_fraction": 0.3,
+                        "latent_fraction": {
+                            "type": "Autocalculate"
+                        },
+                        "occupancy_schedule": "Generic Office Occupancy",
+                        "activity_schedule": "Seated Adult Activity"
+                    },
+                    "lighting": {
+                        "type": "LightingAbridged",
+                        "identifier": "Generic Office Lighting",
+                        "watts_per_area": 10.55,
+                        "return_air_fraction": 0.0,
+                        "radiant_fraction": 0.7,
+                        "visible_fraction": 0.2,
+                        "schedule": "Generic Office Lighting"
+                    },
+                    "electric_equipment": {
+                        "type": "ElectricEquipmentAbridged",
+                        "identifier": "Generic Office Equipment",
+                        "watts_per_area": 10.33,
+                        "radiant_fraction": 0.5,
+                        "latent_fraction": 0.0,
+                        "lost_fraction": 0.0,
+                        "schedule": "Generic Office Equipment"
+                    },
+                    "infiltration": {
+                        "type": "InfiltrationAbridged",
+                        "identifier": "Generic Office Infiltration",
+                        "flow_per_exterior_area": 0.0002266,
+                        "schedule": "Generic Office Infiltration"
+                    },
+                    "ventilation": {
+                        "type": "VentilationAbridged",
+                        "identifier": "Generic Office Ventilation",
+                        "flow_per_person": 0.00236,
+                        "flow_per_area": 0.000305
+                    },
+                    "setpoint": {
+                        "type": "SetpointAbridged",
+                        "identifier": "Generic Office Setpoints",
+                        "heating_schedule": "Generic Office Heating",
+                        "cooling_schedule": "Generic Office Cooling"
+                    }
+                }
+            ],
+            "schedules": [
+                {
+                    "type": "ScheduleRulesetAbridged",
+                    "identifier": "Always On",
+                    "day_schedules": [
+                        {
+                            "type": "ScheduleDay",
+                            "identifier": "Always On_Day Schedule",
+                            "values": [
+                                1.0
+                            ],
+                            "times": [
+                                [
+                                    0,
+                                    0
+                                ]
+                            ],
+                            "interpolate": false
+                        }
+                    ],
+                    "default_day_schedule": "Always On_Day Schedule",
+                    "schedule_type_limit": "Fractional"
+                },
+                {
+                    "type": "ScheduleRulesetAbridged",
+                    "identifier": "Generic Office Heating",
+                    "day_schedules": [
+                        {
+                            "type": "ScheduleDay",
+                            "identifier": "OfficeMedium HTGSETP_SCH_YES_OPTIMUM_Default",
+                            "values": [
+                                15.6
+                            ],
+                            "times": [
+                                [
+                                    0,
+                                    0
+                                ]
+                            ],
+                            "interpolate": false
+                        },
+                        {
+                            "type": "ScheduleDay",
+                            "identifier": "OfficeMedium HTGSETP_SCH_YES_OPTIMUM_Default_SmrDsn",
+                            "values": [
+                                15.6
+                            ],
+                            "times": [
+                                [
+                                    0,
+                                    0
+                                ]
+                            ],
+                            "interpolate": false
+                        },
+                        {
+                            "type": "ScheduleDay",
+                            "identifier": "OfficeMedium HTGSETP_SCH_YES_OPTIMUM_WntrDsn",
+                            "values": [
+                                15.6,
+                                17.6,
+                                19.6,
+                                21.0,
+                                15.6
+                            ],
+                            "times": [
+                                [
+                                    0,
+                                    0
+                                ],
+                                [
+                                    5,
+                                    0
+                                ],
+                                [
+                                    6,
+                                    0
+                                ],
+                                [
+                                    7,
+                                    0
+                                ],
+                                [
+                                    22,
+                                    0
+                                ]
+                            ],
+                            "interpolate": false
+                        },
+                        {
+                            "type": "ScheduleDay",
+                            "identifier": "OfficeMedium HTGSETP_SCH_YES_OPTIMUM_Wkdy",
+                            "values": [
+                                15.6,
+                                17.8,
+                                20.0,
+                                21.0,
+                                15.6
+                            ],
+                            "times": [
+                                [
+                                    0,
+                                    0
+                                ],
+                                [
+                                    5,
+                                    0
+                                ],
+                                [
+                                    6,
+                                    0
+                                ],
+                                [
+                                    7,
+                                    0
+                                ],
+                                [
+                                    22,
+                                    0
+                                ]
+                            ],
+                            "interpolate": false
+                        },
+                        {
+                            "type": "ScheduleDay",
+                            "identifier": "OfficeMedium HTGSETP_SCH_YES_OPTIMUM_Sat",
+                            "values": [
+                                15.6,
+                                17.8,
+                                20.0,
+                                21.0,
+                                15.6
+                            ],
+                            "times": [
+                                [
+                                    0,
+                                    0
+                                ],
+                                [
+                                    5,
+                                    0
+                                ],
+                                [
+                                    6,
+                                    0
+                                ],
+                                [
+                                    7,
+                                    0
+                                ],
+                                [
+                                    17,
+                                    0
+                                ]
+                            ],
+                            "interpolate": false
+                        }
+                    ],
+                    "default_day_schedule": "OfficeMedium HTGSETP_SCH_YES_OPTIMUM_Default",
+                    "schedule_rules": [
+                        {
+                            "type": "ScheduleRuleAbridged",
+                            "schedule_day": "OfficeMedium HTGSETP_SCH_YES_OPTIMUM_Wkdy",
+                            "apply_sunday": false,
+                            "apply_monday": true,
+                            "apply_tuesday": true,
+                            "apply_wednesday": true,
+                            "apply_thursday": true,
+                            "apply_friday": true,
+                            "apply_saturday": false,
+                            "start_date": [
+                                1,
+                                1
+                            ],
+                            "end_date": [
+                                12,
+                                31
+                            ]
+                        },
+                        {
+                            "type": "ScheduleRuleAbridged",
+                            "schedule_day": "OfficeMedium HTGSETP_SCH_YES_OPTIMUM_Sat",
+                            "apply_sunday": false,
+                            "apply_monday": false,
+                            "apply_tuesday": false,
+                            "apply_wednesday": false,
+                            "apply_thursday": false,
+                            "apply_friday": false,
+                            "apply_saturday": true,
+                            "start_date": [
+                                1,
+                                1
+                            ],
+                            "end_date": [
+                                12,
+                                31
+                            ]
+                        }
+                    ],
+                    "holiday_schedule": "OfficeMedium HTGSETP_SCH_YES_OPTIMUM_Default",
+                    "summer_designday_schedule": "OfficeMedium HTGSETP_SCH_YES_OPTIMUM_Default_SmrDsn",
+                    "winter_designday_schedule": "OfficeMedium HTGSETP_SCH_YES_OPTIMUM_WntrDsn",
+                    "schedule_type_limit": "Temperature"
+                },
+                {
+                    "type": "ScheduleRulesetAbridged",
+                    "identifier": "Seated Adult Activity",
+                    "day_schedules": [
+                        {
+                            "type": "ScheduleDay",
+                            "identifier": "Seated Adult Activity_Day Schedule",
+                            "values": [
+                                120.0
+                            ],
+                            "times": [
+                                [
+                                    0,
+                                    0
+                                ]
+                            ],
+                            "interpolate": false
+                        }
+                    ],
+                    "default_day_schedule": "Seated Adult Activity_Day Schedule",
+                    "schedule_type_limit": "Activity Level"
+                },
+                {
+                    "type": "ScheduleRulesetAbridged",
+                    "identifier": "Generic Office Lighting",
+                    "day_schedules": [
+                        {
+                            "type": "ScheduleDay",
+                            "identifier": "OfficeMedium BLDG_LIGHT_SCH_2013_Sun",
+                            "values": [
+                                0.05,
+                                0.04311628,
+                                0.05
+                            ],
+                            "times": [
+                                [
+                                    0,
+                                    0
+                                ],
+                                [
+                                    6,
+                                    0
+                                ],
+                                [
+                                    18,
+                                    0
+                                ]
+                            ],
+                            "interpolate": false
+                        },
+                        {
+                            "type": "ScheduleDay",
+                            "identifier": "OfficeMedium BLDG_LIGHT_SCH_2013_SmrDsn",
+                            "values": [
+                                1.0
+                            ],
+                            "times": [
+                                [
+                                    0,
+                                    0
+                                ]
+                            ],
+                            "interpolate": false
+                        },
+                        {
+                            "type": "ScheduleDay",
+                            "identifier": "OfficeMedium BLDG_LIGHT_SCH_2013_WntrDsn",
+                            "values": [
+                                0.0
+                            ],
+                            "times": [
+                                [
+                                    0,
+                                    0
+                                ]
+                            ],
+                            "interpolate": false
+                        },
+                        {
+                            "type": "ScheduleDay",
+                            "identifier": "OfficeMedium BLDG_LIGHT_SCH_2013_Sat",
+                            "values": [
+                                0.05,
+                                0.08623256,
+                                0.25869768,
+                                0.12934884,
+                                0.04311628,
+                                0.05
+                            ],
+                            "times": [
+                                [
+                                    0,
+                                    0
+                                ],
+                                [
+                                    6,
+                                    0
+                                ],
+                                [
+                                    8,
+                                    0
+                                ],
+                                [
+                                    12,
+                                    0
+                                ],
+                                [
+                                    17,
+                                    0
+                                ],
+                                [
+                                    19,
+                                    0
+                                ]
+                            ],
+                            "interpolate": false
+                        },
+                        {
+                            "type": "ScheduleDay",
+                            "identifier": "OfficeMedium BLDG_LIGHT_SCH_2013_Wkdy",
+                            "values": [
+                                0.05,
+                                0.1,
+                                0.08623256,
+                                0.25869768,
+                                0.77609304,
+                                0.4311628,
+                                0.25869768,
+                                0.17246512,
+                                0.08623256,
+                                0.04311628
+                            ],
+                            "times": [
+                                [
+                                    0,
+                                    0
+                                ],
+                                [
+                                    5,
+                                    0
+                                ],
+                                [
+                                    6,
+                                    0
+                                ],
+                                [
+                                    7,
+                                    0
+                                ],
+                                [
+                                    8,
+                                    0
+                                ],
+                                [
+                                    17,
+                                    0
+                                ],
+                                [
+                                    18,
+                                    0
+                                ],
+                                [
+                                    20,
+                                    0
+                                ],
+                                [
+                                    22,
+                                    0
+                                ],
+                                [
+                                    23,
+                                    0
+                                ]
+                            ],
+                            "interpolate": false
+                        }
+                    ],
+                    "default_day_schedule": "OfficeMedium BLDG_LIGHT_SCH_2013_Sun",
+                    "schedule_rules": [
+                        {
+                            "type": "ScheduleRuleAbridged",
+                            "schedule_day": "OfficeMedium BLDG_LIGHT_SCH_2013_Wkdy",
+                            "apply_sunday": false,
+                            "apply_monday": true,
+                            "apply_tuesday": true,
+                            "apply_wednesday": true,
+                            "apply_thursday": true,
+                            "apply_friday": true,
+                            "apply_saturday": false,
+                            "start_date": [
+                                1,
+                                1
+                            ],
+                            "end_date": [
+                                12,
+                                31
+                            ]
+                        },
+                        {
+                            "type": "ScheduleRuleAbridged",
+                            "schedule_day": "OfficeMedium BLDG_LIGHT_SCH_2013_Sat",
+                            "apply_sunday": false,
+                            "apply_monday": false,
+                            "apply_tuesday": false,
+                            "apply_wednesday": false,
+                            "apply_thursday": false,
+                            "apply_friday": false,
+                            "apply_saturday": true,
+                            "start_date": [
+                                1,
+                                1
+                            ],
+                            "end_date": [
+                                12,
+                                31
+                            ]
+                        }
+                    ],
+                    "holiday_schedule": "OfficeMedium BLDG_LIGHT_SCH_2013_Sat",
+                    "summer_designday_schedule": "OfficeMedium BLDG_LIGHT_SCH_2013_SmrDsn",
+                    "winter_designday_schedule": "OfficeMedium BLDG_LIGHT_SCH_2013_WntrDsn",
+                    "schedule_type_limit": "Fractional"
+                },
+                {
+                    "type": "ScheduleRulesetAbridged",
+                    "identifier": "Generic Office Infiltration",
+                    "day_schedules": [
+                        {
+                            "type": "ScheduleDay",
+                            "identifier": "OfficeMedium INFIL_SCH_PNNL_Default",
+                            "values": [
+                                1.0
+                            ],
+                            "times": [
+                                [
+                                    0,
+                                    0
+                                ]
+                            ],
+                            "interpolate": false
+                        },
+                        {
+                            "type": "ScheduleDay",
+                            "identifier": "OfficeMedium INFIL_SCH_PNNL_Wkdy_SmrDsn",
+                            "values": [
+                                1.0,
+                                0.25,
+                                1.0
+                            ],
+                            "times": [
+                                [
+                                    0,
+                                    0
+                                ],
+                                [
+                                    6,
+                                    0
+                                ],
+                                [
+                                    22,
+                                    0
+                                ]
+                            ],
+                            "interpolate": false
+                        },
+                        {
+                            "type": "ScheduleDay",
+                            "identifier": "OfficeMedium INFIL_SCH_PNNL_Sat_WntrDsn",
+                            "values": [
+                                1.0,
+                                0.25,
+                                1.0
+                            ],
+                            "times": [
+                                [
+                                    0,
+                                    0
+                                ],
+                                [
+                                    6,
+                                    0
+                                ],
+                                [
+                                    18,
+                                    0
+                                ]
+                            ],
+                            "interpolate": false
+                        },
+                        {
+                            "type": "ScheduleDay",
+                            "identifier": "OfficeMedium INFIL_SCH_PNNL_Wkdy",
+                            "values": [
+                                1.0,
+                                0.25,
+                                1.0
+                            ],
+                            "times": [
+                                [
+                                    0,
+                                    0
+                                ],
+                                [
+                                    6,
+                                    0
+                                ],
+                                [
+                                    22,
+                                    0
+                                ]
+                            ],
+                            "interpolate": false
+                        },
+                        {
+                            "type": "ScheduleDay",
+                            "identifier": "OfficeMedium INFIL_SCH_PNNL_Sat",
+                            "values": [
+                                1.0,
+                                0.25,
+                                1.0
+                            ],
+                            "times": [
+                                [
+                                    0,
+                                    0
+                                ],
+                                [
+                                    6,
+                                    0
+                                ],
+                                [
+                                    18,
+                                    0
+                                ]
+                            ],
+                            "interpolate": false
+                        }
+                    ],
+                    "default_day_schedule": "OfficeMedium INFIL_SCH_PNNL_Default",
+                    "schedule_rules": [
+                        {
+                            "type": "ScheduleRuleAbridged",
+                            "schedule_day": "OfficeMedium INFIL_SCH_PNNL_Wkdy",
+                            "apply_sunday": false,
+                            "apply_monday": true,
+                            "apply_tuesday": true,
+                            "apply_wednesday": true,
+                            "apply_thursday": true,
+                            "apply_friday": true,
+                            "apply_saturday": false,
+                            "start_date": [
+                                1,
+                                1
+                            ],
+                            "end_date": [
+                                12,
+                                31
+                            ]
+                        },
+                        {
+                            "type": "ScheduleRuleAbridged",
+                            "schedule_day": "OfficeMedium INFIL_SCH_PNNL_Sat",
+                            "apply_sunday": false,
+                            "apply_monday": false,
+                            "apply_tuesday": false,
+                            "apply_wednesday": false,
+                            "apply_thursday": false,
+                            "apply_friday": false,
+                            "apply_saturday": true,
+                            "start_date": [
+                                1,
+                                1
+                            ],
+                            "end_date": [
+                                12,
+                                31
+                            ]
+                        }
+                    ],
+                    "holiday_schedule": "OfficeMedium INFIL_SCH_PNNL_Default",
+                    "summer_designday_schedule": "OfficeMedium INFIL_SCH_PNNL_Wkdy_SmrDsn",
+                    "winter_designday_schedule": "OfficeMedium INFIL_SCH_PNNL_Sat_WntrDsn",
+                    "schedule_type_limit": "Fractional"
+                },
+                {
+                    "type": "ScheduleRulesetAbridged",
+                    "identifier": "Generic Office Occupancy",
+                    "day_schedules": [
+                        {
+                            "type": "ScheduleDay",
+                            "identifier": "OfficeMedium BLDG_OCC_SCH_Default",
+                            "values": [
+                                0.0,
+                                0.05,
+                                0.0
+                            ],
+                            "times": [
+                                [
+                                    0,
+                                    0
+                                ],
+                                [
+                                    6,
+                                    0
+                                ],
+                                [
+                                    18,
+                                    0
+                                ]
+                            ],
+                            "interpolate": false
+                        },
+                        {
+                            "type": "ScheduleDay",
+                            "identifier": "OfficeMedium BLDG_OCC_SCH_SmrDsn",
+                            "values": [
+                                0.0,
+                                1.0,
+                                0.05
+                            ],
+                            "times": [
+                                [
+                                    0,
+                                    0
+                                ],
+                                [
+                                    6,
+                                    0
+                                ],
+                                [
+                                    22,
+                                    0
+                                ]
+                            ],
+                            "interpolate": false
+                        },
+                        {
+                            "type": "ScheduleDay",
+                            "identifier": "OfficeMedium BLDG_OCC_SCH_WntrDsn",
+                            "values": [
+                                0.0
+                            ],
+                            "times": [
+                                [
+                                    0,
+                                    0
+                                ]
+                            ],
+                            "interpolate": false
+                        },
+                        {
+                            "type": "ScheduleDay",
+                            "identifier": "OfficeMedium BLDG_OCC_SCH_Wkdy",
+                            "values": [
+                                0.0,
+                                0.1,
+                                0.2,
+                                0.95,
+                                0.5,
+                                0.95,
+                                0.3,
+                                0.1,
+                                0.05
+                            ],
+                            "times": [
+                                [
+                                    0,
+                                    0
+                                ],
+                                [
+                                    6,
+                                    0
+                                ],
+                                [
+                                    7,
+                                    0
+                                ],
+                                [
+                                    8,
+                                    0
+                                ],
+                                [
+                                    12,
+                                    0
+                                ],
+                                [
+                                    13,
+                                    0
+                                ],
+                                [
+                                    17,
+                                    0
+                                ],
+                                [
+                                    18,
+                                    0
+                                ],
+                                [
+                                    22,
+                                    0
+                                ]
+                            ],
+                            "interpolate": false
+                        },
+                        {
+                            "type": "ScheduleDay",
+                            "identifier": "OfficeMedium BLDG_OCC_SCH_Sat",
+                            "values": [
+                                0.0,
+                                0.1,
+                                0.3,
+                                0.1,
+                                0.05,
+                                0.0
+                            ],
+                            "times": [
+                                [
+                                    0,
+                                    0
+                                ],
+                                [
+                                    6,
+                                    0
+                                ],
+                                [
+                                    8,
+                                    0
+                                ],
+                                [
+                                    12,
+                                    0
+                                ],
+                                [
+                                    17,
+                                    0
+                                ],
+                                [
+                                    19,
+                                    0
+                                ]
+                            ],
+                            "interpolate": false
+                        }
+                    ],
+                    "default_day_schedule": "OfficeMedium BLDG_OCC_SCH_Default",
+                    "schedule_rules": [
+                        {
+                            "type": "ScheduleRuleAbridged",
+                            "schedule_day": "OfficeMedium BLDG_OCC_SCH_Wkdy",
+                            "apply_sunday": false,
+                            "apply_monday": true,
+                            "apply_tuesday": true,
+                            "apply_wednesday": true,
+                            "apply_thursday": true,
+                            "apply_friday": true,
+                            "apply_saturday": false,
+                            "start_date": [
+                                1,
+                                1
+                            ],
+                            "end_date": [
+                                12,
+                                31
+                            ]
+                        },
+                        {
+                            "type": "ScheduleRuleAbridged",
+                            "schedule_day": "OfficeMedium BLDG_OCC_SCH_Sat",
+                            "apply_sunday": false,
+                            "apply_monday": false,
+                            "apply_tuesday": false,
+                            "apply_wednesday": false,
+                            "apply_thursday": false,
+                            "apply_friday": false,
+                            "apply_saturday": true,
+                            "start_date": [
+                                1,
+                                1
+                            ],
+                            "end_date": [
+                                12,
+                                31
+                            ]
+                        }
+                    ],
+                    "holiday_schedule": "OfficeMedium BLDG_OCC_SCH_Default",
+                    "summer_designday_schedule": "OfficeMedium BLDG_OCC_SCH_SmrDsn",
+                    "winter_designday_schedule": "OfficeMedium BLDG_OCC_SCH_WntrDsn",
+                    "schedule_type_limit": "Fractional"
+                },
+                {
+                    "type": "ScheduleRulesetAbridged",
+                    "identifier": "Generic Office Equipment",
+                    "day_schedules": [
+                        {
+                            "type": "ScheduleDay",
+                            "identifier": "OfficeMedium BLDG_EQUIP_SCH_2013_Sun",
+                            "values": [
+                                0.2307553806,
+                                0.288107175,
+                                0.2307553806
+                            ],
+                            "times": [
+                                [
+                                    0,
+                                    0
+                                ],
+                                [
+                                    6,
+                                    0
+                                ],
+                                [
+                                    18,
+                                    0
+                                ]
+                            ],
+                            "interpolate": false
+                        },
+                        {
+                            "type": "ScheduleDay",
+                            "identifier": "OfficeMedium BLDG_EQUIP_SCH_2013_SmrDsn",
+                            "values": [
+                                1.0
+                            ],
+                            "times": [
+                                [
+                                    0,
+                                    0
+                                ]
+                            ],
+                            "interpolate": false
+                        },
+                        {
+                            "type": "ScheduleDay",
+                            "identifier": "OfficeMedium BLDG_EQUIP_SCH_2013_WntrDsn",
+                            "values": [
+                                0.0
+                            ],
+                            "times": [
+                                [
+                                    0,
+                                    0
+                                ]
+                            ],
+                            "interpolate": false
+                        },
+                        {
+                            "type": "ScheduleDay",
+                            "identifier": "OfficeMedium BLDG_EQUIP_SCH_2013_Sat",
+                            "values": [
+                                0.2307553806,
+                                0.381234796,
+                                0.476543495,
+                                0.3335804465,
+                                0.285926097,
+                                0.2307553806
+                            ],
+                            "times": [
+                                [
+                                    0,
+                                    0
+                                ],
+                                [
+                                    6,
+                                    0
+                                ],
+                                [
+                                    8,
+                                    0
+                                ],
+                                [
+                                    12,
+                                    0
+                                ],
+                                [
+                                    17,
+                                    0
+                                ],
+                                [
+                                    19,
+                                    0
+                                ]
+                            ],
+                            "interpolate": false
+                        },
+                        {
+                            "type": "ScheduleDay",
+                            "identifier": "OfficeMedium BLDG_EQUIP_SCH_2013_Wkdy",
+                            "values": [
+                                0.3076738408,
+                                0.381234796,
+                                0.857778291,
+                                0.762469592,
+                                0.857778291,
+                                0.476543495,
+                                0.381234796
+                            ],
+                            "times": [
+                                [
+                                    0,
+                                    0
+                                ],
+                                [
+                                    6,
+                                    0
+                                ],
+                                [
+                                    8,
+                                    0
+                                ],
+                                [
+                                    12,
+                                    0
+                                ],
+                                [
+                                    13,
+                                    0
+                                ],
+                                [
+                                    17,
+                                    0
+                                ],
+                                [
+                                    18,
+                                    0
+                                ]
+                            ],
+                            "interpolate": false
+                        }
+                    ],
+                    "default_day_schedule": "OfficeMedium BLDG_EQUIP_SCH_2013_Sun",
+                    "schedule_rules": [
+                        {
+                            "type": "ScheduleRuleAbridged",
+                            "schedule_day": "OfficeMedium BLDG_EQUIP_SCH_2013_Wkdy",
+                            "apply_sunday": false,
+                            "apply_monday": true,
+                            "apply_tuesday": true,
+                            "apply_wednesday": true,
+                            "apply_thursday": true,
+                            "apply_friday": true,
+                            "apply_saturday": false,
+                            "start_date": [
+                                1,
+                                1
+                            ],
+                            "end_date": [
+                                12,
+                                31
+                            ]
+                        },
+                        {
+                            "type": "ScheduleRuleAbridged",
+                            "schedule_day": "OfficeMedium BLDG_EQUIP_SCH_2013_Sat",
+                            "apply_sunday": false,
+                            "apply_monday": false,
+                            "apply_tuesday": false,
+                            "apply_wednesday": false,
+                            "apply_thursday": false,
+                            "apply_friday": false,
+                            "apply_saturday": true,
+                            "start_date": [
+                                1,
+                                1
+                            ],
+                            "end_date": [
+                                12,
+                                31
+                            ]
+                        }
+                    ],
+                    "holiday_schedule": "OfficeMedium BLDG_EQUIP_SCH_2013_Sat",
+                    "summer_designday_schedule": "OfficeMedium BLDG_EQUIP_SCH_2013_SmrDsn",
+                    "winter_designday_schedule": "OfficeMedium BLDG_EQUIP_SCH_2013_WntrDsn",
+                    "schedule_type_limit": "Fractional"
+                },
+                {
+                    "type": "ScheduleRulesetAbridged",
+                    "identifier": "Generic Office Cooling",
+                    "day_schedules": [
+                        {
+                            "type": "ScheduleDay",
+                            "identifier": "OfficeMedium CLGSETP_SCH_YES_OPTIMUM_Default",
+                            "values": [
+                                26.7
+                            ],
+                            "times": [
+                                [
+                                    0,
+                                    0
+                                ]
+                            ],
+                            "interpolate": false
+                        },
+                        {
+                            "type": "ScheduleDay",
+                            "identifier": "OfficeMedium CLGSETP_SCH_YES_OPTIMUM_SmrDsn",
+                            "values": [
+                                26.7,
+                                25.7,
+                                25.0,
+                                24.0,
+                                26.7
+                            ],
+                            "times": [
+                                [
+                                    0,
+                                    0
+                                ],
+                                [
+                                    5,
+                                    0
+                                ],
+                                [
+                                    6,
+                                    0
+                                ],
+                                [
+                                    7,
+                                    0
+                                ],
+                                [
+                                    22,
+                                    0
+                                ]
+                            ],
+                            "interpolate": false
+                        },
+                        {
+                            "type": "ScheduleDay",
+                            "identifier": "OfficeMedium CLGSETP_SCH_YES_OPTIMUM_Default_WntrDsn",
+                            "values": [
+                                26.7
+                            ],
+                            "times": [
+                                [
+                                    0,
+                                    0
+                                ]
+                            ],
+                            "interpolate": false
+                        },
+                        {
+                            "type": "ScheduleDay",
+                            "identifier": "OfficeMedium CLGSETP_SCH_YES_OPTIMUM_Wkdy",
+                            "values": [
+                                26.7,
+                                25.6,
+                                25.0,
+                                24.0,
+                                26.7
+                            ],
+                            "times": [
+                                [
+                                    0,
+                                    0
+                                ],
+                                [
+                                    5,
+                                    0
+                                ],
+                                [
+                                    6,
+                                    0
+                                ],
+                                [
+                                    7,
+                                    0
+                                ],
+                                [
+                                    22,
+                                    0
+                                ]
+                            ],
+                            "interpolate": false
+                        },
+                        {
+                            "type": "ScheduleDay",
+                            "identifier": "OfficeMedium CLGSETP_SCH_YES_OPTIMUM_Sat",
+                            "values": [
+                                26.7,
+                                25.7,
+                                25.0,
+                                24.0,
+                                26.7
+                            ],
+                            "times": [
+                                [
+                                    0,
+                                    0
+                                ],
+                                [
+                                    5,
+                                    0
+                                ],
+                                [
+                                    6,
+                                    0
+                                ],
+                                [
+                                    7,
+                                    0
+                                ],
+                                [
+                                    17,
+                                    0
+                                ]
+                            ],
+                            "interpolate": false
+                        }
+                    ],
+                    "default_day_schedule": "OfficeMedium CLGSETP_SCH_YES_OPTIMUM_Default",
+                    "schedule_rules": [
+                        {
+                            "type": "ScheduleRuleAbridged",
+                            "schedule_day": "OfficeMedium CLGSETP_SCH_YES_OPTIMUM_Wkdy",
+                            "apply_sunday": false,
+                            "apply_monday": true,
+                            "apply_tuesday": true,
+                            "apply_wednesday": true,
+                            "apply_thursday": true,
+                            "apply_friday": true,
+                            "apply_saturday": false,
+                            "start_date": [
+                                1,
+                                1
+                            ],
+                            "end_date": [
+                                12,
+                                31
+                            ]
+                        },
+                        {
+                            "type": "ScheduleRuleAbridged",
+                            "schedule_day": "OfficeMedium CLGSETP_SCH_YES_OPTIMUM_Sat",
+                            "apply_sunday": false,
+                            "apply_monday": false,
+                            "apply_tuesday": false,
+                            "apply_wednesday": false,
+                            "apply_thursday": false,
+                            "apply_friday": false,
+                            "apply_saturday": true,
+                            "start_date": [
+                                1,
+                                1
+                            ],
+                            "end_date": [
+                                12,
+                                31
+                            ]
+                        }
+                    ],
+                    "holiday_schedule": "OfficeMedium CLGSETP_SCH_YES_OPTIMUM_Default",
+                    "summer_designday_schedule": "OfficeMedium CLGSETP_SCH_YES_OPTIMUM_SmrDsn",
+                    "winter_designday_schedule": "OfficeMedium CLGSETP_SCH_YES_OPTIMUM_Default_WntrDsn",
+                    "schedule_type_limit": "Temperature"
+                }
+            ],
+            "schedule_type_limits": [
+                {
+                    "type": "ScheduleTypeLimit",
+                    "identifier": "Fractional",
+                    "lower_limit": 0.0,
+                    "upper_limit": 1.0,
+                    "numeric_type": "Continuous",
+                    "unit_type": "Dimensionless"
+                },
+                {
+                    "type": "ScheduleTypeLimit",
+                    "identifier": "Temperature",
+                    "lower_limit": -273.15,
+                    "upper_limit": {
+                        "type": "NoLimit"
+                    },
+                    "numeric_type": "Continuous",
+                    "unit_type": "Temperature"
+                },
+                {
+                    "type": "ScheduleTypeLimit",
+                    "identifier": "Activity Level",
+                    "lower_limit": 0.0,
+                    "upper_limit": {
+                        "type": "NoLimit"
+                    },
+                    "numeric_type": "Continuous",
+                    "unit_type": "ActivityLevel"
+                }
+            ],
+            "ventilation_simulation_control": {
+                "type": "VentilationSimulationControl",
+                "vent_control_type": "SingleZone",
+                "reference_temperature": 20.0,
+                "reference_pressure": 101325.0,
+                "reference_humidity_ratio": 0.0,
+                "building_type": "LowRise",
+                "long_axis_angle": 0.0,
+                "aspect_ratio": 1.0
+            }
+        }
+    },
+    "rooms": [
+        {
+            "type": "Room",
+            "identifier": "SouthRoom",
+            "display_name": "SouthRoom",
+            "properties": {
+                "type": "RoomPropertiesAbridged",
+                "energy": {
+                    "type": "RoomEnergyPropertiesAbridged",
+                    "program_type": "Generic Office Program",
+                    "window_vent_control": {
+                        "type": "VentilationControlAbridged",
+                        "min_indoor_temperature": -100.0,
+                        "max_indoor_temperature": 100.0,
+                        "min_outdoor_temperature": -100.0,
+                        "max_outdoor_temperature": 100.0,
+                        "delta_temperature": -100.0
+                    }
+                }
+            },
+            "faces": [
+                {
+                    "type": "Face",
+                    "identifier": "SouthRoom..Face0",
+                    "display_name": "SouthRoom..Face0",
+                    "properties": {
+                        "type": "FacePropertiesAbridged",
+                        "energy": {
+                            "type": "FaceEnergyPropertiesAbridged"
+                        }
+                    },
+                    "geometry": {
+                        "type": "Face3D",
+                        "boundary": [
+                            [
+                                0.0,
+                                10.0,
+                                0.0
+                            ],
+                            [
+                                20.0,
+                                10.0,
+                                0.0
+                            ],
+                            [
+                                20.0,
+                                0.0,
+                                0.0
+                            ],
+                            [
+                                0.0,
+                                0.0,
+                                0.0
+                            ]
+                        ]
+                    },
+                    "face_type": "Floor",
+                    "boundary_condition": {
+                        "type": "Ground"
+                    }
+                },
+                {
+                    "type": "Face",
+                    "identifier": "SouthRoom..Face1",
+                    "display_name": "SouthRoom..Face1",
+                    "properties": {
+                        "type": "FacePropertiesAbridged",
+                        "energy": {
+                            "type": "FaceEnergyPropertiesAbridged",
+                            "vent_crack": {
+                                "type": "AFNCrack",
+                                "flow_coefficient": 0.006648584928103797,
+                                "flow_exponent": 0.65
+                            }
+                        }
+                    },
+                    "geometry": {
+                        "type": "Face3D",
+                        "boundary": [
+                            [
+                                0.0,
+                                0.0,
+                                3.0
+                            ],
+                            [
+                                0.0,
+                                0.0,
+                                0.0
+                            ],
+                            [
+                                20.0,
+                                0.0,
+                                0.0
+                            ],
+                            [
+                                20.0,
+                                0.0,
+                                3.0
+                            ]
+                        ]
+                    },
+                    "face_type": "Wall",
+                    "boundary_condition": {
+                        "type": "Outdoors",
+                        "sun_exposure": true,
+                        "wind_exposure": true,
+                        "view_factor": {
+                            "type": "Autocalculate"
+                        }
+                    }
+                },
+                {
+                    "type": "Face",
+                    "identifier": "SouthRoom..Face2",
+                    "display_name": "SouthRoom..Face2",
+                    "properties": {
+                        "type": "FacePropertiesAbridged",
+                        "energy": {
+                            "type": "FaceEnergyPropertiesAbridged",
+                            "vent_crack": {
+                                "type": "AFNCrack",
+                                "flow_coefficient": 0.0033242924640518984,
+                                "flow_exponent": 0.65
+                            }
+                        }
+                    },
+                    "geometry": {
+                        "type": "Face3D",
+                        "boundary": [
+                            [
+                                20.0,
+                                0.0,
+                                3.0
+                            ],
+                            [
+                                20.0,
+                                0.0,
+                                0.0
+                            ],
+                            [
+                                20.0,
+                                10.0,
+                                0.0
+                            ],
+                            [
+                                20.0,
+                                10.0,
+                                3.0
+                            ]
+                        ]
+                    },
+                    "face_type": "Wall",
+                    "boundary_condition": {
+                        "type": "Outdoors",
+                        "sun_exposure": true,
+                        "wind_exposure": true,
+                        "view_factor": {
+                            "type": "Autocalculate"
+                        }
+                    }
+                },
+                {
+                    "type": "Face",
+                    "identifier": "SouthRoom..Face3",
+                    "display_name": "SouthRoom..Face3",
+                    "properties": {
+                        "type": "FacePropertiesAbridged",
+                        "energy": {
+                            "type": "FaceEnergyPropertiesAbridged",
+                            "vent_crack": {
+                                "type": "AFNCrack",
+                                "flow_coefficient": 0.126,
+                                "flow_exponent": 0.75
+                            }
+                        }
+                    },
+                    "geometry": {
+                        "type": "Face3D",
+                        "boundary": [
+                            [
+                                20.0,
+                                10.0,
+                                3.0
+                            ],
+                            [
+                                20.0,
+                                10.0,
+                                0.0
+                            ],
+                            [
+                                0.0,
+                                10.0,
+                                0.0
+                            ],
+                            [
+                                0.0,
+                                10.0,
+                                3.0
+                            ]
+                        ]
+                    },
+                    "face_type": "Wall",
+                    "boundary_condition": {
+                        "type": "Surface",
+                        "boundary_condition_objects": [
+                            "NorthRoom..Face1",
+                            "NorthRoom"
+                        ]
+                    },
+                    "apertures": [
+                        {
+                            "type": "Aperture",
+                            "identifier": "SouthRoom..Face3_Glz0",
+                            "display_name": "SouthRoom..Face3_Glz0",
+                            "properties": {
+                                "type": "AperturePropertiesAbridged",
+                                "energy": {
+                                    "type": "ApertureEnergyPropertiesAbridged",
+                                    "vent_opening": {
+                                        "type": "VentilationOpening",
+                                        "fraction_area_operable": 0.5,
+                                        "fraction_height_operable": 1.0,
+                                        "discharge_coefficient": 0.45,
+                                        "wind_cross_vent": false,
+                                        "flow_coefficient_closed": 0.0014,
+                                        "flow_exponent_closed": 0.65,
+                                        "two_way_threshold": 0.0001
+                                    }
+                                }
+                            },
+                            "geometry": {
+                                "type": "Face3D",
+                                "boundary": [
+                                    [
+                                        15.47722557505166,
+                                        10.0,
+                                        2.3215838362577492
+                                    ],
+                                    [
+                                        15.47722557505166,
+                                        10.0,
+                                        0.6784161637422509
+                                    ],
+                                    [
+                                        4.52277442494834,
+                                        10.0,
+                                        0.6784161637422509
+                                    ],
+                                    [
+                                        4.52277442494834,
+                                        10.0,
+                                        2.3215838362577492
+                                    ]
+                                ]
+                            },
+                            "is_operable": true,
+                            "boundary_condition": {
+                                "type": "Surface",
+                                "boundary_condition_objects": [
+                                    "NorthRoom..Face1_Glz0",
+                                    "NorthRoom..Face1",
+                                    "NorthRoom"
+                                ]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "type": "Face",
+                    "identifier": "SouthRoom..Face4",
+                    "display_name": "SouthRoom..Face4",
+                    "properties": {
+                        "type": "FacePropertiesAbridged",
+                        "energy": {
+                            "type": "FaceEnergyPropertiesAbridged",
+                            "vent_crack": {
+                                "type": "AFNCrack",
+                                "flow_coefficient": 0.0033242924640518984,
+                                "flow_exponent": 0.65
+                            }
+                        }
+                    },
+                    "geometry": {
+                        "type": "Face3D",
+                        "boundary": [
+                            [
+                                0.0,
+                                10.0,
+                                3.0
+                            ],
+                            [
+                                0.0,
+                                10.0,
+                                0.0
+                            ],
+                            [
+                                0.0,
+                                0.0,
+                                0.0
+                            ],
+                            [
+                                0.0,
+                                0.0,
+                                3.0
+                            ]
+                        ]
+                    },
+                    "face_type": "Wall",
+                    "boundary_condition": {
+                        "type": "Outdoors",
+                        "sun_exposure": true,
+                        "wind_exposure": true,
+                        "view_factor": {
+                            "type": "Autocalculate"
+                        }
+                    }
+                },
+                {
+                    "type": "Face",
+                    "identifier": "SouthRoom..Face5",
+                    "display_name": "SouthRoom..Face5",
+                    "properties": {
+                        "type": "FacePropertiesAbridged",
+                        "energy": {
+                            "type": "FaceEnergyPropertiesAbridged",
+                            "vent_crack": {
+                                "type": "AFNCrack",
+                                "flow_coefficient": 0.022161949760345988,
+                                "flow_exponent": 0.65
+                            }
+                        }
+                    },
+                    "geometry": {
+                        "type": "Face3D",
+                        "boundary": [
+                            [
+                                0.0,
+                                0.0,
+                                3.0
+                            ],
+                            [
+                                20.0,
+                                0.0,
+                                3.0
+                            ],
+                            [
+                                20.0,
+                                10.0,
+                                3.0
+                            ],
+                            [
+                                0.0,
+                                10.0,
+                                3.0
+                            ]
+                        ]
+                    },
+                    "face_type": "RoofCeiling",
+                    "boundary_condition": {
+                        "type": "Outdoors",
+                        "sun_exposure": true,
+                        "wind_exposure": true,
+                        "view_factor": {
+                            "type": "Autocalculate"
+                        }
+                    }
+                }
+            ]
+        },
+        {
+            "type": "Room",
+            "identifier": "NorthRoom",
+            "display_name": "NorthRoom",
+            "properties": {
+                "type": "RoomPropertiesAbridged",
+                "energy": {
+                    "type": "RoomEnergyPropertiesAbridged",
+                    "program_type": "Generic Office Program",
+                    "window_vent_control": {
+                        "type": "VentilationControlAbridged",
+                        "min_indoor_temperature": -100.0,
+                        "max_indoor_temperature": 100.0,
+                        "min_outdoor_temperature": -100.0,
+                        "max_outdoor_temperature": 100.0,
+                        "delta_temperature": -100.0
+                    }
+                }
+            },
+            "faces": [
+                {
+                    "type": "Face",
+                    "identifier": "NorthRoom..Face0",
+                    "display_name": "NorthRoom..Face0",
+                    "properties": {
+                        "type": "FacePropertiesAbridged",
+                        "energy": {
+                            "type": "FaceEnergyPropertiesAbridged"
+                        }
+                    },
+                    "geometry": {
+                        "type": "Face3D",
+                        "boundary": [
+                            [
+                                0.0,
+                                20.0,
+                                0.0
+                            ],
+                            [
+                                20.0,
+                                20.0,
+                                0.0
+                            ],
+                            [
+                                20.0,
+                                10.0,
+                                0.0
+                            ],
+                            [
+                                0.0,
+                                10.0,
+                                0.0
+                            ]
+                        ]
+                    },
+                    "face_type": "Floor",
+                    "boundary_condition": {
+                        "type": "Ground"
+                    }
+                },
+                {
+                    "type": "Face",
+                    "identifier": "NorthRoom..Face1",
+                    "display_name": "NorthRoom..Face1",
+                    "properties": {
+                        "type": "FacePropertiesAbridged",
+                        "energy": {
+                            "type": "FaceEnergyPropertiesAbridged",
+                            "vent_crack": {
+                                "type": "AFNCrack",
+                                "flow_coefficient": 0.126,
+                                "flow_exponent": 0.75
+                            }
+                        }
+                    },
+                    "geometry": {
+                        "type": "Face3D",
+                        "boundary": [
+                            [
+                                0.0,
+                                10.0,
+                                3.0
+                            ],
+                            [
+                                0.0,
+                                10.0,
+                                0.0
+                            ],
+                            [
+                                20.0,
+                                10.0,
+                                0.0
+                            ],
+                            [
+                                20.0,
+                                10.0,
+                                3.0
+                            ]
+                        ]
+                    },
+                    "face_type": "Wall",
+                    "boundary_condition": {
+                        "type": "Surface",
+                        "boundary_condition_objects": [
+                            "SouthRoom..Face3",
+                            "SouthRoom"
+                        ]
+                    },
+                    "apertures": [
+                        {
+                            "type": "Aperture",
+                            "identifier": "NorthRoom..Face1_Glz0",
+                            "display_name": "NorthRoom..Face1_Glz0",
+                            "properties": {
+                                "type": "AperturePropertiesAbridged",
+                                "energy": {
+                                    "type": "ApertureEnergyPropertiesAbridged",
+                                    "vent_opening": {
+                                        "type": "VentilationOpening",
+                                        "fraction_area_operable": 0.5,
+                                        "fraction_height_operable": 1.0,
+                                        "discharge_coefficient": 0.45,
+                                        "wind_cross_vent": false,
+                                        "flow_coefficient_closed": 0.0014,
+                                        "flow_exponent_closed": 0.65,
+                                        "two_way_threshold": 0.0001
+                                    }
+                                }
+                            },
+                            "geometry": {
+                                "type": "Face3D",
+                                "boundary": [
+                                    [
+                                        4.52277442494834,
+                                        10.0,
+                                        2.3215838362577492
+                                    ],
+                                    [
+                                        4.52277442494834,
+                                        10.0,
+                                        0.6784161637422509
+                                    ],
+                                    [
+                                        15.47722557505166,
+                                        10.0,
+                                        0.6784161637422509
+                                    ],
+                                    [
+                                        15.47722557505166,
+                                        10.0,
+                                        2.3215838362577492
+                                    ]
+                                ]
+                            },
+                            "is_operable": true,
+                            "boundary_condition": {
+                                "type": "Surface",
+                                "boundary_condition_objects": [
+                                    "SouthRoom..Face3_Glz0",
+                                    "SouthRoom..Face3",
+                                    "SouthRoom"
+                                ]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "type": "Face",
+                    "identifier": "NorthRoom..Face2",
+                    "display_name": "NorthRoom..Face2",
+                    "properties": {
+                        "type": "FacePropertiesAbridged",
+                        "energy": {
+                            "type": "FaceEnergyPropertiesAbridged",
+                            "vent_crack": {
+                                "type": "AFNCrack",
+                                "flow_coefficient": 0.0033242924640518984,
+                                "flow_exponent": 0.65
+                            }
+                        }
+                    },
+                    "geometry": {
+                        "type": "Face3D",
+                        "boundary": [
+                            [
+                                20.0,
+                                10.0,
+                                3.0
+                            ],
+                            [
+                                20.0,
+                                10.0,
+                                0.0
+                            ],
+                            [
+                                20.0,
+                                20.0,
+                                0.0
+                            ],
+                            [
+                                20.0,
+                                20.0,
+                                3.0
+                            ]
+                        ]
+                    },
+                    "face_type": "Wall",
+                    "boundary_condition": {
+                        "type": "Outdoors",
+                        "sun_exposure": true,
+                        "wind_exposure": true,
+                        "view_factor": {
+                            "type": "Autocalculate"
+                        }
+                    }
+                },
+                {
+                    "type": "Face",
+                    "identifier": "NorthRoom..Face3",
+                    "display_name": "NorthRoom..Face3",
+                    "properties": {
+                        "type": "FacePropertiesAbridged",
+                        "energy": {
+                            "type": "FaceEnergyPropertiesAbridged",
+                            "vent_crack": {
+                                "type": "AFNCrack",
+                                "flow_coefficient": 0.006648584928103797,
+                                "flow_exponent": 0.65
+                            }
+                        }
+                    },
+                    "geometry": {
+                        "type": "Face3D",
+                        "boundary": [
+                            [
+                                20.0,
+                                20.0,
+                                3.0
+                            ],
+                            [
+                                20.0,
+                                20.0,
+                                0.0
+                            ],
+                            [
+                                0.0,
+                                20.0,
+                                0.0
+                            ],
+                            [
+                                0.0,
+                                20.0,
+                                3.0
+                            ]
+                        ]
+                    },
+                    "face_type": "Wall",
+                    "boundary_condition": {
+                        "type": "Outdoors",
+                        "sun_exposure": true,
+                        "wind_exposure": true,
+                        "view_factor": {
+                            "type": "Autocalculate"
+                        }
+                    }
+                },
+                {
+                    "type": "Face",
+                    "identifier": "NorthRoom..Face4",
+                    "display_name": "NorthRoom..Face4",
+                    "properties": {
+                        "type": "FacePropertiesAbridged",
+                        "energy": {
+                            "type": "FaceEnergyPropertiesAbridged",
+                            "vent_crack": {
+                                "type": "AFNCrack",
+                                "flow_coefficient": 0.0033242924640518984,
+                                "flow_exponent": 0.65
+                            }
+                        }
+                    },
+                    "geometry": {
+                        "type": "Face3D",
+                        "boundary": [
+                            [
+                                0.0,
+                                20.0,
+                                3.0
+                            ],
+                            [
+                                0.0,
+                                20.0,
+                                0.0
+                            ],
+                            [
+                                0.0,
+                                10.0,
+                                0.0
+                            ],
+                            [
+                                0.0,
+                                10.0,
+                                3.0
+                            ]
+                        ]
+                    },
+                    "face_type": "Wall",
+                    "boundary_condition": {
+                        "type": "Outdoors",
+                        "sun_exposure": true,
+                        "wind_exposure": true,
+                        "view_factor": {
+                            "type": "Autocalculate"
+                        }
+                    }
+                },
+                {
+                    "type": "Face",
+                    "identifier": "NorthRoom..Face5",
+                    "display_name": "NorthRoom..Face5",
+                    "properties": {
+                        "type": "FacePropertiesAbridged",
+                        "energy": {
+                            "type": "FaceEnergyPropertiesAbridged",
+                            "vent_crack": {
+                                "type": "AFNCrack",
+                                "flow_coefficient": 0.022161949760345988,
+                                "flow_exponent": 0.65
+                            }
+                        }
+                    },
+                    "geometry": {
+                        "type": "Face3D",
+                        "boundary": [
+                            [
+                                0.0,
+                                10.0,
+                                3.0
+                            ],
+                            [
+                                20.0,
+                                10.0,
+                                3.0
+                            ],
+                            [
+                                20.0,
+                                20.0,
+                                3.0
+                            ],
+                            [
+                                0.0,
+                                20.0,
+                                3.0
+                            ]
+                        ]
+                    },
+                    "face_type": "RoofCeiling",
+                    "boundary_condition": {
+                        "type": "Outdoors",
+                        "sun_exposure": true,
+                        "wind_exposure": true,
+                        "view_factor": {
+                            "type": "Autocalculate"
+                        }
+                    }
+                }
+            ]
+        }
+    ],
+    "version": "1.33.1"
+}

--- a/samples/model/model_energy_window_ventilation.json
+++ b/samples/model/model_energy_window_ventilation.json
@@ -32,28 +32,6 @@
             "schedules": [
                 {
                     "type": "ScheduleRulesetAbridged",
-                    "identifier": "House Heating",
-                    "day_schedules": [
-                        {
-                            "type": "ScheduleDay",
-                            "identifier": "House Heating_Day Schedule",
-                            "values": [
-                                20.0
-                            ],
-                            "times": [
-                                [
-                                    0,
-                                    0
-                                ]
-                            ],
-                            "interpolate": false
-                        }
-                    ],
-                    "default_day_schedule": "House Heating_Day Schedule",
-                    "schedule_type_limit": "Temperature"
-                },
-                {
-                    "type": "ScheduleRulesetAbridged",
                     "identifier": "House Cooling",
                     "day_schedules": [
                         {
@@ -72,6 +50,28 @@
                         }
                     ],
                     "default_day_schedule": "House Cooling_Day Schedule",
+                    "schedule_type_limit": "Temperature"
+                },
+                {
+                    "type": "ScheduleRulesetAbridged",
+                    "identifier": "House Heating",
+                    "day_schedules": [
+                        {
+                            "type": "ScheduleDay",
+                            "identifier": "House Heating_Day Schedule",
+                            "values": [
+                                20.0
+                            ],
+                            "times": [
+                                [
+                                    0,
+                                    0
+                                ]
+                            ],
+                            "interpolate": false
+                        }
+                    ],
+                    "default_day_schedule": "House Heating_Day Schedule",
                     "schedule_type_limit": "Temperature"
                 },
                 {
@@ -116,7 +116,17 @@
                     "numeric_type": "Continuous",
                     "unit_type": "Temperature"
                 }
-            ]
+            ],
+            "ventilation_simulation_control": {
+                "type": "VentilationSimulationControl",
+                "vent_control_type": "SingleZone",
+                "reference_temperature": 20.0,
+                "reference_pressure": 101325.0,
+                "reference_humidity_ratio": 0.0,
+                "building_type": "LowRise",
+                "long_axis_angle": 0.0,
+                "aspect_ratio": 1.0
+            }
         }
     },
     "rooms": [
@@ -141,8 +151,7 @@
                         "max_indoor_temperature": 27.0,
                         "min_outdoor_temperature": 12.0,
                         "max_outdoor_temperature": 30.0,
-                        "delta_temperature": -100.0,
-                        "schedule": "Always On"
+                        "delta_temperature": -100.0
                     }
                 }
             },
@@ -522,5 +531,6 @@
                 }
             ]
         }
-    ]
+    ],
+    "version": "1.33.1"
 }

--- a/samples/ventcool/ventilation_crack.json
+++ b/samples/ventcool/ventilation_crack.json
@@ -1,0 +1,5 @@
+{
+    "type": "AFNCrack",
+    "flow_coefficient": 0.01,
+    "flow_exponent": 0.65
+}

--- a/samples/ventcool/ventilation_simulation_control.json
+++ b/samples/ventcool/ventilation_simulation_control.json
@@ -1,0 +1,10 @@
+{
+    "type": "VentilationSimulationControl",
+    "vent_control_type": "MultiZoneWithoutDistribution",
+    "reference_temperature": 21.0,
+    "reference_pressure": 101325.0,
+    "reference_humidity_ratio": 0.5,
+    "building_type": "LowRise",
+    "long_axis_angle": 90.0,
+    "aspect_ratio": 0.5
+}

--- a/scripts/sample_model.py
+++ b/scripts/sample_model.py
@@ -1,4 +1,5 @@
 # coding=utf-8
+
 from honeybee.model import Model
 from honeybee.room import Room
 from honeybee.face import Face
@@ -18,6 +19,7 @@ from honeybee_energy.schedule.ruleset import ScheduleRuleset
 from honeybee_energy.load.setpoint import Setpoint
 from honeybee_energy.ventcool.opening import VentilationOpening
 from honeybee_energy.ventcool.control import VentilationControl
+from honeybee_energy.ventcool import afn
 from honeybee_energy.hvac.allair.vav import VAV
 from honeybee_energy.hvac.doas.fcu import FCUwithDOAS
 from honeybee_energy.hvac.heatcool.windowac import WindowAC
@@ -462,6 +464,45 @@ def model_energy_window_ventilation(directory):
         json.dump(model.to_dict(included_prop=['energy']), fp, indent=4)
 
 
+def model_energy_afn_multizone(directory):
+
+    # South Room
+    szone_pts = Face3D(
+        [Point3D(0, 0), Point3D(20, 0), Point3D(20, 10), Point3D(0, 10)])
+    sroom = Room.from_polyface3d(
+        'SouthRoom', Polyface3D.from_offset_face(szone_pts, 3))
+
+    # North Room
+    nzone_pts = Face3D(
+        [Point3D(0, 10), Point3D(20, 10), Point3D(20, 20), Point3D(0, 20)])
+    nroom = Room.from_polyface3d(
+        'NorthRoom', Polyface3D.from_offset_face(nzone_pts, 3))
+
+    # Add adjacent interior windows
+    sroom[3].apertures_by_ratio(0.3)  # Window on south face
+    nroom[1].apertures_by_ratio(0.3)  # Window on north face
+
+    # rooms
+    rooms = [sroom, nroom]
+    for room in rooms:
+        # Add program and hvac
+        room.properties.energy.program_type = prog_type_lib.office_program
+
+    # Make model
+    model = Model('Two_Zone_Simple', rooms)
+
+    # Make interior faces
+    Room.solve_adjacency(rooms, 0.01)
+
+    # Make afn
+    window_vent_controls = [VentilationControl().duplicate() for _ in rooms]
+    afn.generate(model.rooms, window_vent_controls)
+
+    dest_file = os.path.join(directory, 'model_energy_afn.json')
+    with open(dest_file, 'w') as fp:
+        json.dump(model.to_dict(included_prop=['energy']), fp, indent=4)
+
+
 def model_energy_allair_hvac(directory):
     first_floor = Room.from_box('First_Floor', 10, 10, 3, origin=Point3D(0, 0, 0))
     second_floor = Room.from_box('Second_Floor', 10, 10, 3, origin=Point3D(0, 0, 3))
@@ -740,6 +781,7 @@ model_energy_doas_hvac(sample_directory)
 model_energy_window_ac(sample_directory)
 model_energy_properties_office(sample_directory)
 model_energy_window_ventilation(sample_directory)
+model_energy_afn_multizone(sample_directory)
 model_5vertex_sub_faces(sample_directory)
 model_5vertex_sub_faces_interior(sample_directory)
 

--- a/scripts/sample_ventcool.py
+++ b/scripts/sample_ventcool.py
@@ -1,9 +1,12 @@
 # coding=utf-8
-from honeybee_energy.ventcool.opening import VentilationOpening
-from honeybee_energy.ventcool.control import VentilationControl
+
 from honeybee_energy.schedule.day import ScheduleDay
 from honeybee_energy.schedule.ruleset import ScheduleRuleset
 import honeybee_energy.lib.scheduletypelimits as schedule_types
+from honeybee_energy.ventcool.opening import VentilationOpening
+from honeybee_energy.ventcool.control import VentilationControl
+from honeybee_energy.ventcool.crack import AFNCrack
+from honeybee_energy.ventcool.simulation import VentilationSimulationControl
 
 from ladybug.dt import Time
 
@@ -39,6 +42,23 @@ def ventilation_control_detailed(directory):
         json.dump(ventilation.to_dict(abridged=True), fp, indent=4)
 
 
+def ventilation_crack(directory):
+    vent_afn = AFNCrack(flow_coefficient=0.01, flow_exponent=0.65)
+
+    dest_file = os.path.join(directory, 'ventilation_crack.json')
+    with open(dest_file, 'w') as fp:
+        json.dump(vent_afn.to_dict(), fp, indent=4)
+
+
+def ventilation_simulation_control(directory):
+    vent_sim = VentilationSimulationControl(
+        'MultiZoneWithoutDistribution', 21, 101325, 0.5, 'LowRise', 90, 0.5)
+
+    dest_file = os.path.join(directory, 'ventilation_simulation_control.json')
+    with open(dest_file, 'w') as fp:
+        json.dump(vent_sim.to_dict(), fp, indent=4)
+
+
 # run all functions within the file
 master_dir = os.path.split(os.path.dirname(__file__))[0]
 sample_directory = os.path.join(master_dir, 'samples', 'ventcool')
@@ -46,3 +66,5 @@ sample_directory = os.path.join(master_dir, 'samples', 'ventcool')
 ventilation_opening_default(sample_directory)
 ventilation_control_simple(sample_directory)
 ventilation_control_detailed(sample_directory)
+ventilation_crack(sample_directory)
+ventilation_simulation_control(sample_directory)

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -58,6 +58,11 @@ def test_model_energy_window_ventilation():
     Model.parse_file(file_path)
 
 
+def test_model_energy_afn():
+    file_path = os.path.join(target_folder, 'model_energy_afn.json')
+    Model.parse_file(file_path)
+
+
 def test_model_energy_allair_hvac():
     file_path = os.path.join(target_folder, 'model_energy_allair_hvac.json')
     Model.parse_file(file_path)

--- a/tests/test_ventcool.py
+++ b/tests/test_ventcool.py
@@ -1,4 +1,6 @@
-from honeybee_schema.energy.ventcool import VentilationControlAbridged, VentilationOpening
+from honeybee_schema.energy.ventcool import VentilationControlAbridged, \
+    VentilationOpening, VentilationSimulationControl, AFNCrack
+
 import os
 
 # target folder where all of the samples live
@@ -15,6 +17,17 @@ def test_ventilation_control_simple():
     file_path = os.path.join(target_folder, 'ventilation_control_simple.json')
     VentilationControlAbridged.parse_file(file_path)
 
+
 def test_ventilation_control_detailed():
     file_path = os.path.join(target_folder, 'ventilation_control_detailed.json')
     VentilationControlAbridged.parse_file(file_path)
+
+
+def test_ventilation_crack():
+    file_path = os.path.join(target_folder, 'ventilation_crack.json')
+    AFNCrack.parse_file(file_path)
+
+
+def ventilation_simulation_control(directory):
+    file_path = os.path.join(target_folder, 'ventilation_simulation_control.json')
+    VentilationSimulationControl.parse_file(file_path)


### PR DESCRIPTION
@chriswmackey, 
cc @mostaphaRoudsari 

This is the first draft of the AFN objects we are adding to the VentCool module, in the Honeybee Schema. Once I implement the AFN objects in honeybee-energy, I'll create some test jsons, and add unit tests to this PR. 

Note that the EnergyPlus implementation will require EMS objects (i.e. EMS:Sensor, EMS:Actuator, EMS:ProgramCallingManager, and the EMS:Program), to coordinate these AFN objects with the VentControl in Honeybee. None of these EMS objects are referenced in the schema since it'll just be referencing existing objects and doesn't need to be modified by the user.

Also, you'll notice that in the AFNSimulationControl object, there's a number of fields requiring the geometric properties of a building footprint that is roughly rectangular. Since we are auto-calculating the wind pressure coefficients for external surfaces, the AFN assumes the building being simulated is roughly rectangular. If you want to model non-rectangular buildings for the AFN, we'll need to expose classes to add custom wind pressure data. 

Technically, we could calculate these geometric properties from the model and eliminate the need to expose these parameters (similar to how we don't expose the window dimension parameters in AFN since we can derive it internally in honeybee-energy). However, that will require deriving a correctly oriented bounding box (not an axis-aligned bounding box), which I believe is a geometric method we don't have yet. Until then we may need to have this option to enter these geometric properties manually.  Let me know if you want me to write up a oriented bbox/ long/short axis method and get rid of this. 