### PR TITLE
fix(wea): Update Wea schema to include datetimes

### DIFF
--- a/honeybee_schema/radiance/wea.py
+++ b/honeybee_schema/radiance/wea.py
@@ -1,5 +1,5 @@
 """Wea Schema"""
-from pydantic import Field, constr, confloat
+from pydantic import Field, root_validator, constr, confloat, conlist
 from typing import List
 
 from .._base import NoExtraBaseModel
@@ -77,14 +77,16 @@ class Wea(NoExtraBaseModel):
 
     direct_normal_irradiance: List[confloat(ge=0)] = Field(
         ...,
+        min_items=1,
         description='A list of numbers for the annual direct normal irradiance '
-        'in W/m2.'
+        'in W/m2. The length of this list must match the diffuse_horizontal_irradiance.'
     )
 
     diffuse_horizontal_irradiance: List[confloat(ge=0)] = Field(
         ...,
+        min_items=1,
         description='A list of numbers for the annual diffuse horizontal irradiance '
-        'in W/m2.'
+        'in W/m2. The length of this list must match the direct_normal_irradiance.'
     )
 
     timestep: int = Field(
@@ -97,3 +99,29 @@ class Wea(NoExtraBaseModel):
         False,
         description='A boolean to indicate if values are representing a leap year.'
     )
+
+    datetimes: List[conlist(int, min_items=4, max_items=5)] = Field(
+        None,
+        min_items=1,
+        description='A list with a length matching the length of the irradiance lists. '
+        'Each item in the list should also be a list with 4 integers that together '
+        'represent a DateTime in the format [month, day, hour, minute]. DateTimes are '
+        'not required when the input irradiance data is annual but are required in '
+        'all other cases.'
+    )
+
+    @root_validator
+    def check_datetimes_required(cls, values):
+        """Ensure that datetimes are provided if the values are not annual."""
+        dir_norm = values.get('direct_normal_irradiance')
+        dif_horiz = values.get('diffuse_horizontal_irradiance')
+        timestep = values.get('timestep')
+        is_leap_year = values.get('is_leap_year')
+        datetimes = values.get('datetimes')
+        assert len(dir_norm) == len(dif_horiz), 'Wea direct normal irradiance must ' \
+            'have the same number of values as the diffuse horizontal irradiance.'
+        step_count = 8784 * timestep if is_leap_year else 8760 * timestep
+        if len(dir_norm) != step_count:  # not annual data; ensure we have datetimes
+            assert datetimes is not None, 'Wea datetimes must be provided when ' \
+                'irradiance data is not annual.'
+        return values


### PR DESCRIPTION
I also added a check to ensure that the lengths of the two irradiance lists match and that datetimes are provided whenever the length of these lists is not annual.

I'm just letting you know about the update, @mostaphaRoudsari , and everything I'm adding here is in accordance with the PR you just reviewed.