### PR TITLE
feat(hvac): Add classes for detailed HVAC templates

### DIFF
--- a/honeybee_schema/energy/designday.py
+++ b/honeybee_schema/energy/designday.py
@@ -210,7 +210,3 @@ class DesignDay(NoExtraBaseModel):
     )
 
     sky_condition: Union[ASHRAEClearSky, ASHRAETau]
-
-
-if __name__ == '__main__':
-    print(DesignDay.schema_json(indent=2))

--- a/honeybee_schema/energy/hvac/_template.py
+++ b/honeybee_schema/energy/hvac/_template.py
@@ -1,0 +1,28 @@
+"""Base class for HVAC systems following a standards template."""
+from pydantic import Field
+from enum import Enum
+
+from .._base import IDdEnergyBaseModel
+
+
+class Vintages(str, Enum):
+    ashrae_2013 = '90.1-2013'
+    ashrae_2010 = '90.1-2010'
+    ashrae_2007 = '90.1-2007'
+    ashrae_2004 = '90.1-2004'
+    doe_ref_1980_2004 = 'DOE Ref 1980-2004'
+    doe_ref_pre_1980 = 'DOE Ref Pre-1980'
+
+
+class _TemplateSystem(IDdEnergyBaseModel):
+    """Base class for HVAC systems following a standards template."""
+
+    vintage: Vintages = Field(
+        Vintages.ashrae_2013,
+        description='Text for the vintage of the template system. This will be used '
+        'to set efficiencies for various pieces of equipment within the system. '
+        'Further information about these defaults can be found in the version of '
+        'ASHRAE 90.1 corresponding to the selected vintage. Read-only versions '
+        'of the standard can be found at: https://www.ashrae.org/technical-resources/'
+        'standards-and-guidelines/read-only-versions-of-ashrae-standards'
+    )

--- a/honeybee_schema/energy/hvac/allair.py
+++ b/honeybee_schema/energy/hvac/allair.py
@@ -1,0 +1,180 @@
+"""All-air HVAC systems, providing ventilation and meeting thermal demand with air."""
+from pydantic import Field, constr
+from typing import Union
+from enum import Enum
+
+from ._template import _TemplateSystem
+from ...altnumber import Autosize
+
+
+class AllAirEconomizerType(str, Enum):
+    inferred = 'Inferred'
+    no_economizer = 'NoEconomizer'
+    differential_dry_bulb = 'DifferentialDryBulb'
+    differential_enthalpy = 'DifferentialEnthalpy'
+
+
+class _AllAirBase(_TemplateSystem):
+    """Base class for all-air systems."""
+
+    economizer_type: AllAirEconomizerType = Field(
+        AllAirEconomizerType.inferred,
+        description='Text to indicate the type of air-side economizer used on '
+        'the system (from the AllAirEconomizerType enumeration). If Inferred, the '
+        'economizer will be set to whatever is recommended for the given vintage.'
+    )
+
+    sensible_heat_recovery: Union[Autosize, float] = Field(
+        Autosize(),
+        ge=0,
+        le=1,
+        description='A number between 0 and 1 for the effectiveness of sensible '
+        'heat recovery within the system. If None or Autosize, it will be whatever '
+        'is recommended for the given vintage.'
+    )
+
+    latent_heat_recovery: Union[Autosize, float] = Field(
+        Autosize(),
+        ge=0,
+        le=1,
+        description='A number between 0 and 1 for the effectiveness of latent '
+        'heat recovery within the system. If None or Autosize, it will be whatever '
+        'is recommended for the given vintage.'
+    )
+
+
+class VAVEquipmentType(str, Enum):
+    vav_chill_gbr = 'VAV chiller with gas boiler reheat'
+    vav_chill_ashp = 'VAV chiller with central air source heat pump reheat'
+    vav_chill_dhw = 'VAV chiller with district hot water reheat'
+    vav_chill_pfp = 'VAV chiller with PFP boxes'
+    vav_chill_gcr = 'VAV chiller with gas coil reheat'
+    vav_chill_base = 'VAV chiller with no reheat with baseboard electric'
+    vav_chill_guh = 'VAV chiller with no reheat with gas unit heaters'
+    vav_chill_zhp = 'VAV chiller with no reheat with zone heat pump'
+    vav_ac_chill_gbr = 'VAV air-cooled chiller with gas boiler reheat'
+    vav_ac_chill_ashp = 'VAV air-cooled chiller with central air source heat pump reheat'
+    vav_ac_chill_dhw = 'VAV air-cooled chiller with district hot water reheat'
+    vav_ac_chill_pfp = 'VAV air-cooled chiller with PFP boxes'
+    vav_ac_chill_gcr = 'VAV air-cooled chiller with gas coil reheat'
+    vav_ac_chill_base = 'VAV air-cooled chiller with no reheat with baseboard electric'
+    vav_ac_chill_guh = 'VAV air-cooled chiller with no reheat with gas unit heaters'
+    vav_ac_chill_zhp = 'VAV air-cooled chiller with no reheat with zone heat pump'
+    vav_dcw_gbr = 'VAV district chilled water with gas boiler reheat'
+    vav_dcw_ashp = 'VAV district chilled water with central air source heat pump reheat'
+    vav_dcw_dhw = 'VAV district chilled water with district hot water reheat'
+    vav_dcw_pfp = 'VAV district chilled water with PFP boxes'
+    vav_dcw_gcr = 'VAV district chilled water with gas coil reheat'
+    vav_dcw_base = 'VAV district chilled water with no reheat with baseboard electric'
+    vav_dcw_guh = 'VAV district chilled water with no reheat with gas unit heaters'
+    vav_dcw_zhp = 'VAV district chilled water with no reheat with zone heat pump'
+
+
+class PVAVEquipmentType(str, Enum):
+    pvav_gbr = 'PVAV with gas boiler reheat'
+    pvav_ashp = 'PVAV with central air source heat pump reheat'
+    pvav_dhw = 'PVAV with district hot water reheat'
+    pvav_pfp = 'PVAV with PFP boxes'
+    pvav_ger = 'PVAV with gas heat with electric reheat'
+
+
+class PSZEquipmentType(str, Enum):
+    psz_e_base = 'PSZ-AC with baseboard electric'
+    psz_gb_base = 'PSZ-AC with baseboard gas boiler'
+    psz_dhw_base = 'PSZ-AC with baseboard district hot water'
+    psz_guh = 'PSZ-AC with gas unit heaters'
+    psz_ec = 'PSZ-AC with electric coil'
+    psz_gc = 'PSZ-AC with gas coil'
+    psz_gb = 'PSZ-AC with gas boiler'
+    psz_ashp = 'PSZ-AC with central air source heat pump'
+    psz_dhw = 'PSZ-AC with district hot water'
+    psz_ac = 'PSZ-AC with no heat'
+    psz_dcw_e_base = 'PSZ-AC district chilled water with baseboard electric'
+    psz_dcw_gb_base = 'PSZ-AC district chilled water with baseboard gas boiler'
+    psz_dcw_dhw_base = 'PSZ-AC district chilled water with baseboard district hot water'
+    psz_dcw_guh = 'PSZ-AC district chilled water with gas unit heaters'
+    psz_dcw_ec = 'PSZ-AC district chilled water with electric coil'
+    psz_dcw_gc = 'PSZ-AC district chilled water with gas coil'
+    psz_dcw_gb = 'PSZ-AC district chilled water with gas boiler'
+    psz_dcw_ashp = 'PSZ-AC district chilled water with central air source heat pump'
+    psz_dcw_dhw = 'PSZ-AC district chilled water with district hot water'
+    psz_dcw_ac = 'PSZ-AC district chilled water with no heat'
+    psz_hp = 'PSZ-HP'
+
+
+class PTACEquipmentType(str, Enum):
+    ptac_e_base = 'PTAC with baseboard electric'
+    ptac_gb_base = 'PTAC with baseboard gas boiler'
+    ptac_dhw_base = 'PTAC with baseboard district hot water'
+    ptac_guh = 'PTAC with gas unit heaters'
+    ptac_ec = 'PTAC with electric coil'
+    ptac_gc = 'PTAC with gas coil'
+    ptac_gb = 'PTAC with gas boiler'
+    ptac_ashp = 'PTAC with central air source heat pump'
+    ptac_dhw = 'PTAC with district hot water'
+    ptac = 'PTAC with no heat'
+    pthp = 'PTHP'
+
+
+class FurnaceEquipmentType(str, Enum):
+    furnace = 'Forced air furnace'
+
+
+class VAV(_AllAirBase):
+    """Variable Air Volume (VAV) HVAC system."""
+
+    type: constr(regex='^VAV$') = 'VAV'
+
+    equipment_type: VAVEquipmentType = Field(
+        VAVEquipmentType.vav_chill_gbr,
+        description='Text for the specific type of system equipment from the '
+        'VAVEquipmentType enumeration.'
+    )
+
+
+class PVAV(_AllAirBase):
+    """Packaged Variable Air Volume (PVAV) HVAC system."""
+
+    type: constr(regex='^PVAV$') = 'PVAV'
+
+    equipment_type: PVAVEquipmentType = Field(
+        PVAVEquipmentType.pvav_gbr,
+        description='Text for the specific type of system equipment from the '
+        'VAVEquipmentType enumeration.'
+    )
+
+
+class PSZ(_AllAirBase):
+    """Packaged Single-Zone (PSZ) HVAC system."""
+
+    type: constr(regex='^PSZ$') = 'PSZ'
+
+    equipment_type: PSZEquipmentType = Field(
+        PSZEquipmentType.psz_e_base,
+        description='Text for the specific type of system equipment from the '
+        'PVAVEquipmentType enumeration.'
+    )
+
+
+class PTAC(_AllAirBase):
+    """Packaged Terminal Air Conditioning (PTAC) or Heat Pump (PTHP) HVAC system."""
+
+    type: constr(regex='^PTAC$') = 'PTAC'
+
+    equipment_type: PTACEquipmentType = Field(
+        PTACEquipmentType.ptac_e_base,
+        description='Text for the specific type of system equipment from the '
+        'PTACEquipmentType enumeration.'
+    )
+
+
+class ForcedAirFurnace(_AllAirBase):
+    """Forced Air Furnace HVAC system. Intended for spaces only requiring heating."""
+
+    type: constr(regex='^ForcedAirFurnace$') = 'ForcedAirFurnace'
+
+    equipment_type: FurnaceEquipmentType = Field(
+        FurnaceEquipmentType.furnace,
+        description='Text for the specific type of system equipment from the '
+        'FurnaceEquipmentType enumeration.'
+    )

--- a/honeybee_schema/energy/hvac/doas.py
+++ b/honeybee_schema/energy/hvac/doas.py
@@ -1,0 +1,97 @@
+"""HVAC systems with DOAS, separating ventilation and meeting thermal demand."""
+from pydantic import Field, constr
+from typing import Union
+from enum import Enum
+
+from ._template import _TemplateSystem
+from ...altnumber import Autosize
+
+
+class _DOASBase(_TemplateSystem):
+    """Base class for DOAS systems."""
+
+    sensible_heat_recovery: Union[Autosize, float] = Field(
+        Autosize(),
+        ge=0,
+        le=1,
+        description='A number between 0 and 1 for the effectiveness of sensible '
+        'heat recovery within the system. If None or Autosize, it will be whatever '
+        'is recommended for the given vintage.'
+    )
+
+    latent_heat_recovery: Union[Autosize, float] = Field(
+        Autosize(),
+        ge=0,
+        le=1,
+        description='A number between 0 and 1 for the effectiveness of latent '
+        'heat recovery within the system. If None or Autosize, it will be whatever '
+        'is recommended for the given vintage.'
+    )
+
+
+class FCUwithDOASEquipmentType(str, Enum):
+    fcu_chill_gb = 'DOAS with fan coil chiller with boiler'
+    fcu_chill_ashp = 'DOAS with fan coil chiller with central air source heat pump'
+    fcu_chill_dhw = 'DOAS with fan coil chiller with district hot water'
+    fcu_chill_base = 'DOAS with fan coil chiller with baseboard electric'
+    fcu_chill_guh = 'DOAS with fan coil chiller with gas unit heaters'
+    fcu_chill = 'DOAS with fan coil chiller with no heat'
+    fcu_ac_chill_gb = 'DOAS with fan coil air-cooled chiller with boiler'
+    fcu_ac_chill_ashp = 'DOAS with fan coil air-cooled chiller with central air source heat pump'
+    fcu_ac_chill_dhw = 'DOAS with fan coil air-cooled chiller with district hot water'
+    fcu_ac_chill_base = 'DOAS with fan coil air-cooled chiller with baseboard electric'
+    fcu_ac_chill_guh = 'DOAS with fan coil air-cooled chiller with gas unit heaters'
+    fcu_ac_chill = 'DOAS with fan coil air-cooled chiller with no heat'
+    fcu_dcw_gb = 'DOAS with fan coil district chilled water with boiler'
+    fcu_dcw_ashp = 'DOAS with fan coil district chilled water with central air source heat pump'
+    fcu_dcw_dhw = 'DOAS with fan coil district chilled water with district hot water'
+    fcu_dcw_base = 'DOAS with fan coil district chilled water with baseboard electric'
+    fcu_dcw_guh = 'DOAS with fan coil district chilled water with gas unit heaters'
+    fcu_dcw = 'DOAS with fan coil district chilled water with no heat'
+
+
+class WSHPwithDOASEquipmentType(str, Enum):
+    wshp_fc_gb = 'DOAS with water source heat pumps fluid cooler with boiler'
+    wshp_ct_gb = 'DOAS with water source heat pumps cooling tower with boiler'
+    wshp_gshp = 'DOAS with water source heat pumps with ground source heat pump'
+    wshp_dcw_dhw = 'DOAS with water source heat pumps district chilled water with district hot water'
+
+
+class VRFwithDOASEquipmentType(str, Enum):
+    vrf = 'DOAS with VRF'
+
+
+class FCUwithDOAS(_DOASBase):
+    """Fan Coil Unit (FCU) with DOAS HVAC system."""
+
+    type: constr(regex='^FCUwithDOAS$') = 'FCUwithDOAS'
+
+    equipment_type: FCUwithDOASEquipmentType = Field(
+        FCUwithDOASEquipmentType.fcu_chill_gb,
+        description='Text for the specific type of system equipment from the '
+        'FCUwithDOASEquipmentType enumeration.'
+    )
+
+
+class WSHPwithDOAS(_DOASBase):
+    """Water Source Heat Pump (WSHP) with DOAS HVAC system."""
+
+    type: constr(regex='^WSHPwithDOAS$') = 'WSHPwithDOAS'
+
+    equipment_type: WSHPwithDOASEquipmentType = Field(
+        WSHPwithDOASEquipmentType.wshp_fc_gb,
+        description='Text for the specific type of system equipment from the '
+        'WSHPwithDOASEquipmentType enumeration.'
+    )
+
+
+class VRFwithDOAS(_DOASBase):
+    """Variable Refrigerant Flow (VRF) with DOAS HVAC system."""
+
+    type: constr(regex='^VRFwithDOAS$') = 'VRFwithDOAS'
+
+    equipment_type: VRFwithDOASEquipmentType = Field(
+        VRFwithDOASEquipmentType.vrf,
+        description='Text for the specific type of system equipment from the '
+        'VRFwithDOASEquipmentType enumeration.'
+    )

--- a/honeybee_schema/energy/hvac/heatcool.py
+++ b/honeybee_schema/energy/hvac/heatcool.py
@@ -1,0 +1,180 @@
+"""Heating/cooling systems without any ventilation."""
+from pydantic import Field, constr
+from enum import Enum
+
+from ._template import _TemplateSystem
+
+
+class _HeatCoolBase(_TemplateSystem):
+    """Base class for all heating/cooling systems without any ventilation."""
+
+
+class FCUEquipmentType(str, Enum):
+    fcu_chill_gb = 'Fan coil chiller with boiler'
+    fcu_chill_ashp = 'Fan coil chiller with central air source heat pump'
+    fcu_chill_dhw = 'Fan coil chiller with district hot water'
+    fcu_chill_base = 'Fan coil chiller with baseboard electric'
+    fcu_chill_guh = 'Fan coil chiller with gas unit heaters'
+    fcu_chill = 'Fan coil chiller with no heat'
+    fcu_ac_chill_gb = 'Fan coil air-cooled chiller with boiler'
+    fcu_ac_chill_ashp = 'Fan coil air-cooled chiller with central air source heat pump'
+    fcu_ac_chill_dhw = 'Fan coil air-cooled chiller with district hot water'
+    fcu_ac_chill_base = 'Fan coil air-cooled chiller with baseboard electric'
+    fcu_ac_chill_guh = 'Fan coil air-cooled chiller with gas unit heaters'
+    fcu_ac_chill = 'Fan coil air-cooled chiller with no heat'
+    fcu_dcw_gb = 'Fan coil district chilled water with boiler'
+    fcu_dcw_ashp = 'Fan coil district chilled water with central air source heat pump'
+    fcu_dcw_dhw = 'Fan coil district chilled water with district hot water'
+    fcu_dcw_base = 'Fan coil district chilled water with baseboard electric'
+    fcu_dcw_guh = 'Fan coil district chilled water with gas unit heaters'
+    fcu_dcw = 'Fan coil district chilled water with no heat'
+
+
+class BaseboardEquipmentType(str, Enum):
+    e_base = 'Baseboard electric'
+    gb_base = 'Baseboard gas boiler'
+    ashp_base = 'Baseboard central air source heat pump'
+    dhw_base = 'Baseboard district hot water'
+
+
+class EvaporativeCoolerEquipmentType(str, Enum):
+    evap_e_base = 'Direct evap coolers with baseboard electric'
+    evap_gb_base = 'Direct evap coolers with baseboard gas boiler'
+    evap_ashp_base = 'Direct evap coolers with baseboard central air source heat pump'
+    evap_dhw_base = 'Direct evap coolers with baseboard district hot water'
+    evap_furnace = 'Direct evap coolers with forced air furnace'
+    evap_guh = 'Direct evap coolers with gas unit heaters'
+    evap = 'Direct evap coolers with no heat'
+
+
+class WSHPEquipmentType(str, Enum):
+    wshp_fc_gb = 'Water source heat pumps fluid cooler with boiler'
+    wshp_ct_gb = 'Water source heat pumps cooling tower with boiler'
+    wshp_gshp = 'Water source heat pumps with ground source heat pump'
+    wshp_dcw_dhw = 'Water source heat pumps district chilled water with district hot water'
+
+
+class ResidentialEquipmentType(str, Enum):
+    res_ac_e_base = 'Residential AC with baseboard electric'
+    res_ac_gb_base = 'Residential AC with baseboard gas boiler'
+    res_ac_ashp_base = 'Residential AC with baseboard central air source heat pump'
+    res_ac_dhw_base = 'Residential AC with baseboard district hot water'
+    res_ac_furnace = 'Residential AC with residential forced air furnace'
+    res_ac = 'Residential AC with no heat'
+    res_hp = 'Residential heat pump'
+    res_hp_no_cool = 'Residential heat pump with no cooling'
+    res_furnace = 'Residential forced air furnace'
+
+
+class WindowACEquipmentType(str, Enum):
+    win_ac_e_base = 'Window AC with baseboard electric'
+    win_ac_gb_base = 'Window AC with baseboard gas boiler'
+    win_ac_ashp_base = 'Window AC with baseboard central air source heat pump'
+    win_ac_dhw_base = 'Window AC with baseboard district hot water'
+    win_ac_furnace = 'Window AC with forced air furnace'
+    win_ac_guh = 'Window AC with unit heaters'
+    win_ac = 'Window AC with no heat'
+
+
+class VRFEquipmentType(str, Enum):
+    vrf = 'VRF'
+
+
+class GasUnitHeaterEquipmentType(str, Enum):
+    guh = 'Gas unit heaters'
+
+
+class FCU(_HeatCoolBase):
+    """Fan Coil Unit (FCU) heating/cooling system (with no ventilation)."""
+
+    type: constr(regex='^FCU$') = 'FCU'
+
+    equipment_type: FCUEquipmentType = Field(
+        FCUEquipmentType.fcu_chill_gb,
+        description='Text for the specific type of system equipment from the '
+        'FCUEquipmentType enumeration.'
+    )
+
+
+class Baseboard(_HeatCoolBase):
+    """Baseboard heating system. Intended for spaces only requiring heating."""
+
+    type: constr(regex='^Baseboard$') = 'Baseboard'
+
+    equipment_type: BaseboardEquipmentType = Field(
+        BaseboardEquipmentType.e_base,
+        description='Text for the specific type of system equipment from the '
+        'BaseboardEquipmentType enumeration.'
+    )
+
+
+class EvaporativeCooler(_HeatCoolBase):
+    """Direct evaporative cooling systems (with optional heating)."""
+
+    type: constr(regex='^EvaporativeCooler$') = 'EvaporativeCooler'
+
+    equipment_type: EvaporativeCoolerEquipmentType = Field(
+        EvaporativeCoolerEquipmentType.evap_e_base,
+        description='Text for the specific type of system equipment from the '
+        'EvaporativeCoolerEquipmentType enumeration.'
+    )
+
+
+class WSHP(_HeatCoolBase):
+    """Direct evaporative cooling systems (with optional heating)."""
+
+    type: constr(regex='^WSHP$') = 'WSHP'
+
+    equipment_type: WSHPEquipmentType = Field(
+        WSHPEquipmentType.wshp_fc_gb,
+        description='Text for the specific type of system equipment from the '
+        'WSHPEquipmentType enumeration.'
+    )
+
+
+class Residential(_HeatCoolBase):
+    """Residential Air Conditioning, Heat Pump or Furnace system."""
+
+    type: constr(regex='^Residential$') = 'Residential'
+
+    equipment_type: ResidentialEquipmentType = Field(
+        ResidentialEquipmentType.res_ac_e_base,
+        description='Text for the specific type of system equipment from the '
+        'ResidentialEquipmentType enumeration.'
+    )
+
+
+class WindowAC(_HeatCoolBase):
+    """Window Air Conditioning cooling system (with optional heating)."""
+
+    type: constr(regex='^WindowAC$') = 'WindowAC'
+
+    equipment_type: WindowACEquipmentType = Field(
+        WindowACEquipmentType.win_ac_e_base,
+        description='Text for the specific type of system equipment from the '
+        'WindowACEquipmentType enumeration.'
+    )
+
+
+class VRF(_HeatCoolBase):
+    """Variable Refrigerant Flow (VRF) heating/cooling system (with no ventilation)."""
+
+    type: constr(regex='^VRF$') = 'VRF'
+
+    equipment_type: VRFEquipmentType = Field(
+        VRFEquipmentType.vrf,
+        description='Text for the specific type of system equipment from the '
+        'VRFEquipmentType enumeration.'
+    )
+
+
+class GasUnitHeater(_HeatCoolBase):
+    """Gas unit heating system. Intended for spaces only requiring heating."""
+
+    type: constr(regex='^GasUnitHeater$') = 'GasUnitHeater'
+
+    equipment_type: GasUnitHeaterEquipmentType = Field(
+        GasUnitHeaterEquipmentType.guh,
+        description='Text for the specific type of system equipment from the '
+        'GasUnitHeaterEquipmentType enumeration.'
+    )

--- a/honeybee_schema/energy/hvac/idealair.py
+++ b/honeybee_schema/energy/hvac/idealair.py
@@ -3,8 +3,8 @@ from pydantic import Field, root_validator, constr
 from typing import Union
 from enum import Enum
 
-from ._base import IDdEnergyBaseModel
-from ..altnumber import NoLimit, Autosize
+from .._base import IDdEnergyBaseModel
+from ...altnumber import NoLimit, Autosize
 
 
 class EconomizerType(str, Enum):
@@ -105,7 +105,3 @@ class IdealAirSystemAbridged(IDdEnergyBaseModel):
         assert heat_temp > cool_temp, 'IdealAirSystem heating_air_temperature must be ' \
             'greater than cooling_air_temperature.'
         return values
-
-
-if __name__ == '__main__':
-    print(IdealAirSystemAbridged.schema_json(indent=2))

--- a/honeybee_schema/energy/material.py
+++ b/honeybee_schema/energy/material.py
@@ -739,15 +739,3 @@ class EnergyWindowMaterialBlind(IDdEnergyBaseModel):
         description='The effective area for air flow at the right side of the shade,'
         ' divided by the vertical area between glass and shade. The default value is 0.5.'
     )
-
-
-if __name__ == '__main__':
-    print(EnergyMaterial.schema_json(indent=2))
-    print(EnergyMaterialNoMass.schema_json(indent=2))
-    print(EnergyWindowMaterialSimpleGlazSys.schema_json(indent=2))
-    print(EnergyWindowMaterialGlazing.schema_json(indent=2))
-    print(EnergyWindowMaterialGas.schema_json(indent=2))
-    print(EnergyWindowMaterialGasMixture.schema_json(indent=2))
-    print(EnergyWindowMaterialGasCustom.schema_json(indent=2))
-    print(EnergyWindowMaterialBlind.schema_json(indent=2))
-    print(EnergyWindowMaterialShade.schema_json(indent=2))

--- a/honeybee_schema/energy/properties.py
+++ b/honeybee_schema/energy/properties.py
@@ -18,7 +18,11 @@ from .load import PeopleAbridged, LightingAbridged, ElectricEquipmentAbridged, \
 from .ventcool import VentilationControlAbridged, VentilationOpening
 from .schedule import ScheduleTypeLimit, ScheduleRulesetAbridged, \
     ScheduleFixedIntervalAbridged, ScheduleRuleset, ScheduleFixedInterval
-from .hvac import IdealAirSystemAbridged
+from .hvac.idealair import IdealAirSystemAbridged
+from .hvac.allair import VAV, PVAV, PSZ, PTAC, ForcedAirFurnace
+from .hvac.doas import FCUwithDOAS, WSHPwithDOAS, VRFwithDOAS
+from .hvac.heatcool import FCU, WSHP, VRF, Baseboard, EvaporativeCooler, Residential, \
+    WindowAC, GasUnitHeater
 
 
 class ShadeEnergyPropertiesAbridged(NoExtraBaseModel):
@@ -210,7 +214,9 @@ class ModelEnergyProperties(NoExtraBaseModel):
         'materials needed to make the Model constructions.'
     )
 
-    hvacs: List[Union[IdealAirSystemAbridged]] = Field(
+    hvacs: List[Union[IdealAirSystemAbridged, VAV, PVAV, PSZ, PTAC, ForcedAirFurnace,
+                      FCUwithDOAS, WSHPwithDOAS, VRFwithDOAS, FCU, WSHP, VRF, Baseboard,
+                      EvaporativeCooler, Residential, WindowAC, GasUnitHeater]] = Field(
         default=None,
         description='List of all unique HVAC systems in the Model.'
     )

--- a/honeybee_schema/energy/simulation.py
+++ b/honeybee_schema/energy/simulation.py
@@ -339,7 +339,3 @@ class SimulationParameter(NoExtraBaseModel):
         description='Text for the terrain in which the model sits. This is used '
         'to determine the wind profile over the height of the rooms.'
     )
-
-
-if __name__ == '__main__':
-    print(SimulationParameter.schema_json(indent=2))

--- a/samples/hvac/fcu_with_doas_template.json
+++ b/samples/hvac/fcu_with_doas_template.json
@@ -1,0 +1,8 @@
+{
+    "type": "FCUwithDOAS",
+    "identifier": "FCU System with DOAS Enthalpy Wheel",
+    "vintage": "90.1-2013",
+    "equipment_type": "DOAS with fan coil chiller with boiler",
+    "sensible_heat_recovery": 0.81,
+    "latent_heat_recovery": 0.67
+}

--- a/samples/hvac/vav_template.json
+++ b/samples/hvac/vav_template.json
@@ -1,0 +1,9 @@
+{
+    "type": "VAV",
+    "identifier": "VAV System with Glycol Loop",
+    "vintage": "90.1-2010",
+    "equipment_type": "VAV chiller with gas boiler reheat",
+    "economizer_type": "DifferentialDryBulb",
+    "sensible_heat_recovery": 0.55,
+    "latent_heat_recovery": 0.0
+}

--- a/samples/hvac/window_ac_with_baseboard_template.json
+++ b/samples/hvac/window_ac_with_baseboard_template.json
@@ -1,0 +1,6 @@
+{
+    "type": "WindowAC",
+    "identifier": "FCU System with DOAS Heat Recovery",
+    "vintage": "90.1-2013",
+    "equipment_type": "Window AC with baseboard gas boiler"
+}

--- a/samples/model/model_energy_allair_hvac.json
+++ b/samples/model/model_energy_allair_hvac.json
@@ -1,0 +1,2191 @@
+{
+    "type": "Model",
+    "identifier": "Model_Energy_Allair_HVAC",
+    "display_name": "Model_Energy_Allair_HVAC",
+    "units": "Meters",
+    "properties": {
+        "type": "ModelProperties",
+        "energy": {
+            "type": "ModelEnergyProperties",
+            "construction_sets": [],
+            "constructions": [],
+            "materials": [],
+            "hvacs": [
+                {
+                    "type": "VAV",
+                    "identifier": "VAV System with Glycol Loop",
+                    "vintage": "90.1-2010",
+                    "equipment_type": "VAV chiller with gas boiler reheat",
+                    "economizer_type": "DifferentialDryBulb",
+                    "sensible_heat_recovery": 0.55,
+                    "latent_heat_recovery": 0.0
+                }
+            ],
+            "program_types": [
+                {
+                    "type": "ProgramTypeAbridged",
+                    "identifier": "Generic Office Program",
+                    "people": {
+                        "type": "PeopleAbridged",
+                        "identifier": "Generic Office People",
+                        "people_per_area": 0.0565,
+                        "radiant_fraction": 0.3,
+                        "latent_fraction": {
+                            "type": "Autocalculate"
+                        },
+                        "occupancy_schedule": "Generic Office Occupancy",
+                        "activity_schedule": "Seated Adult Activity"
+                    },
+                    "lighting": {
+                        "type": "LightingAbridged",
+                        "identifier": "Generic Office Lighting",
+                        "watts_per_area": 10.55,
+                        "return_air_fraction": 0.0,
+                        "radiant_fraction": 0.7,
+                        "visible_fraction": 0.2,
+                        "schedule": "Generic Office Lighting"
+                    },
+                    "electric_equipment": {
+                        "type": "ElectricEquipmentAbridged",
+                        "identifier": "Generic Office Equipment",
+                        "watts_per_area": 10.33,
+                        "radiant_fraction": 0.5,
+                        "latent_fraction": 0.0,
+                        "lost_fraction": 0.0,
+                        "schedule": "Generic Office Equipment"
+                    },
+                    "infiltration": {
+                        "type": "InfiltrationAbridged",
+                        "identifier": "Generic Office Infiltration",
+                        "flow_per_exterior_area": 0.0002266,
+                        "schedule": "Generic Office Infiltration"
+                    },
+                    "ventilation": {
+                        "type": "VentilationAbridged",
+                        "identifier": "Generic Office Ventilation",
+                        "flow_per_person": 0.00236,
+                        "flow_per_area": 0.000305
+                    },
+                    "setpoint": {
+                        "type": "SetpointAbridged",
+                        "identifier": "Generic Office Setpoints",
+                        "heating_schedule": "Generic Office Heating",
+                        "cooling_schedule": "Generic Office Cooling"
+                    }
+                }
+            ],
+            "schedules": [
+                {
+                    "type": "ScheduleRulesetAbridged",
+                    "identifier": "Generic Office Heating",
+                    "day_schedules": [
+                        {
+                            "type": "ScheduleDay",
+                            "identifier": "OfficeMedium HTGSETP_SCH_YES_OPTIMUM_Default",
+                            "values": [
+                                15.6
+                            ],
+                            "times": [
+                                [
+                                    0,
+                                    0
+                                ]
+                            ],
+                            "interpolate": false
+                        },
+                        {
+                            "type": "ScheduleDay",
+                            "identifier": "OfficeMedium HTGSETP_SCH_YES_OPTIMUM_Default_SmrDsn",
+                            "values": [
+                                15.6
+                            ],
+                            "times": [
+                                [
+                                    0,
+                                    0
+                                ]
+                            ],
+                            "interpolate": false
+                        },
+                        {
+                            "type": "ScheduleDay",
+                            "identifier": "OfficeMedium HTGSETP_SCH_YES_OPTIMUM_WntrDsn",
+                            "values": [
+                                15.6,
+                                17.6,
+                                19.6,
+                                21.0,
+                                15.6
+                            ],
+                            "times": [
+                                [
+                                    0,
+                                    0
+                                ],
+                                [
+                                    5,
+                                    0
+                                ],
+                                [
+                                    6,
+                                    0
+                                ],
+                                [
+                                    7,
+                                    0
+                                ],
+                                [
+                                    22,
+                                    0
+                                ]
+                            ],
+                            "interpolate": false
+                        },
+                        {
+                            "type": "ScheduleDay",
+                            "identifier": "OfficeMedium HTGSETP_SCH_YES_OPTIMUM_Wkdy",
+                            "values": [
+                                15.6,
+                                17.8,
+                                20.0,
+                                21.0,
+                                15.6
+                            ],
+                            "times": [
+                                [
+                                    0,
+                                    0
+                                ],
+                                [
+                                    5,
+                                    0
+                                ],
+                                [
+                                    6,
+                                    0
+                                ],
+                                [
+                                    7,
+                                    0
+                                ],
+                                [
+                                    22,
+                                    0
+                                ]
+                            ],
+                            "interpolate": false
+                        },
+                        {
+                            "type": "ScheduleDay",
+                            "identifier": "OfficeMedium HTGSETP_SCH_YES_OPTIMUM_Sat",
+                            "values": [
+                                15.6,
+                                17.8,
+                                20.0,
+                                21.0,
+                                15.6
+                            ],
+                            "times": [
+                                [
+                                    0,
+                                    0
+                                ],
+                                [
+                                    5,
+                                    0
+                                ],
+                                [
+                                    6,
+                                    0
+                                ],
+                                [
+                                    7,
+                                    0
+                                ],
+                                [
+                                    17,
+                                    0
+                                ]
+                            ],
+                            "interpolate": false
+                        }
+                    ],
+                    "default_day_schedule": "OfficeMedium HTGSETP_SCH_YES_OPTIMUM_Default",
+                    "schedule_rules": [
+                        {
+                            "type": "ScheduleRuleAbridged",
+                            "schedule_day": "OfficeMedium HTGSETP_SCH_YES_OPTIMUM_Wkdy",
+                            "apply_sunday": false,
+                            "apply_monday": true,
+                            "apply_tuesday": true,
+                            "apply_wednesday": true,
+                            "apply_thursday": true,
+                            "apply_friday": true,
+                            "apply_saturday": false,
+                            "start_date": [
+                                1,
+                                1
+                            ],
+                            "end_date": [
+                                12,
+                                31
+                            ]
+                        },
+                        {
+                            "type": "ScheduleRuleAbridged",
+                            "schedule_day": "OfficeMedium HTGSETP_SCH_YES_OPTIMUM_Sat",
+                            "apply_sunday": false,
+                            "apply_monday": false,
+                            "apply_tuesday": false,
+                            "apply_wednesday": false,
+                            "apply_thursday": false,
+                            "apply_friday": false,
+                            "apply_saturday": true,
+                            "start_date": [
+                                1,
+                                1
+                            ],
+                            "end_date": [
+                                12,
+                                31
+                            ]
+                        }
+                    ],
+                    "holiday_schedule": "OfficeMedium HTGSETP_SCH_YES_OPTIMUM_Default",
+                    "summer_designday_schedule": "OfficeMedium HTGSETP_SCH_YES_OPTIMUM_Default_SmrDsn",
+                    "winter_designday_schedule": "OfficeMedium HTGSETP_SCH_YES_OPTIMUM_WntrDsn",
+                    "schedule_type_limit": "Temperature"
+                },
+                {
+                    "type": "ScheduleRulesetAbridged",
+                    "identifier": "Generic Office Cooling",
+                    "day_schedules": [
+                        {
+                            "type": "ScheduleDay",
+                            "identifier": "OfficeMedium CLGSETP_SCH_YES_OPTIMUM_Default",
+                            "values": [
+                                26.7
+                            ],
+                            "times": [
+                                [
+                                    0,
+                                    0
+                                ]
+                            ],
+                            "interpolate": false
+                        },
+                        {
+                            "type": "ScheduleDay",
+                            "identifier": "OfficeMedium CLGSETP_SCH_YES_OPTIMUM_SmrDsn",
+                            "values": [
+                                26.7,
+                                25.7,
+                                25.0,
+                                24.0,
+                                26.7
+                            ],
+                            "times": [
+                                [
+                                    0,
+                                    0
+                                ],
+                                [
+                                    5,
+                                    0
+                                ],
+                                [
+                                    6,
+                                    0
+                                ],
+                                [
+                                    7,
+                                    0
+                                ],
+                                [
+                                    22,
+                                    0
+                                ]
+                            ],
+                            "interpolate": false
+                        },
+                        {
+                            "type": "ScheduleDay",
+                            "identifier": "OfficeMedium CLGSETP_SCH_YES_OPTIMUM_Default_WntrDsn",
+                            "values": [
+                                26.7
+                            ],
+                            "times": [
+                                [
+                                    0,
+                                    0
+                                ]
+                            ],
+                            "interpolate": false
+                        },
+                        {
+                            "type": "ScheduleDay",
+                            "identifier": "OfficeMedium CLGSETP_SCH_YES_OPTIMUM_Wkdy",
+                            "values": [
+                                26.7,
+                                25.6,
+                                25.0,
+                                24.0,
+                                26.7
+                            ],
+                            "times": [
+                                [
+                                    0,
+                                    0
+                                ],
+                                [
+                                    5,
+                                    0
+                                ],
+                                [
+                                    6,
+                                    0
+                                ],
+                                [
+                                    7,
+                                    0
+                                ],
+                                [
+                                    22,
+                                    0
+                                ]
+                            ],
+                            "interpolate": false
+                        },
+                        {
+                            "type": "ScheduleDay",
+                            "identifier": "OfficeMedium CLGSETP_SCH_YES_OPTIMUM_Sat",
+                            "values": [
+                                26.7,
+                                25.7,
+                                25.0,
+                                24.0,
+                                26.7
+                            ],
+                            "times": [
+                                [
+                                    0,
+                                    0
+                                ],
+                                [
+                                    5,
+                                    0
+                                ],
+                                [
+                                    6,
+                                    0
+                                ],
+                                [
+                                    7,
+                                    0
+                                ],
+                                [
+                                    17,
+                                    0
+                                ]
+                            ],
+                            "interpolate": false
+                        }
+                    ],
+                    "default_day_schedule": "OfficeMedium CLGSETP_SCH_YES_OPTIMUM_Default",
+                    "schedule_rules": [
+                        {
+                            "type": "ScheduleRuleAbridged",
+                            "schedule_day": "OfficeMedium CLGSETP_SCH_YES_OPTIMUM_Wkdy",
+                            "apply_sunday": false,
+                            "apply_monday": true,
+                            "apply_tuesday": true,
+                            "apply_wednesday": true,
+                            "apply_thursday": true,
+                            "apply_friday": true,
+                            "apply_saturday": false,
+                            "start_date": [
+                                1,
+                                1
+                            ],
+                            "end_date": [
+                                12,
+                                31
+                            ]
+                        },
+                        {
+                            "type": "ScheduleRuleAbridged",
+                            "schedule_day": "OfficeMedium CLGSETP_SCH_YES_OPTIMUM_Sat",
+                            "apply_sunday": false,
+                            "apply_monday": false,
+                            "apply_tuesday": false,
+                            "apply_wednesday": false,
+                            "apply_thursday": false,
+                            "apply_friday": false,
+                            "apply_saturday": true,
+                            "start_date": [
+                                1,
+                                1
+                            ],
+                            "end_date": [
+                                12,
+                                31
+                            ]
+                        }
+                    ],
+                    "holiday_schedule": "OfficeMedium CLGSETP_SCH_YES_OPTIMUM_Default",
+                    "summer_designday_schedule": "OfficeMedium CLGSETP_SCH_YES_OPTIMUM_SmrDsn",
+                    "winter_designday_schedule": "OfficeMedium CLGSETP_SCH_YES_OPTIMUM_Default_WntrDsn",
+                    "schedule_type_limit": "Temperature"
+                },
+                {
+                    "type": "ScheduleRulesetAbridged",
+                    "identifier": "Seated Adult Activity",
+                    "day_schedules": [
+                        {
+                            "type": "ScheduleDay",
+                            "identifier": "Seated Adult Activity_Day Schedule",
+                            "values": [
+                                120.0
+                            ],
+                            "times": [
+                                [
+                                    0,
+                                    0
+                                ]
+                            ],
+                            "interpolate": false
+                        }
+                    ],
+                    "default_day_schedule": "Seated Adult Activity_Day Schedule",
+                    "schedule_type_limit": "Activity Level"
+                },
+                {
+                    "type": "ScheduleRulesetAbridged",
+                    "identifier": "Generic Office Infiltration",
+                    "day_schedules": [
+                        {
+                            "type": "ScheduleDay",
+                            "identifier": "OfficeMedium INFIL_SCH_PNNL_Default",
+                            "values": [
+                                1.0
+                            ],
+                            "times": [
+                                [
+                                    0,
+                                    0
+                                ]
+                            ],
+                            "interpolate": false
+                        },
+                        {
+                            "type": "ScheduleDay",
+                            "identifier": "OfficeMedium INFIL_SCH_PNNL_Wkdy_SmrDsn",
+                            "values": [
+                                1.0,
+                                0.25,
+                                1.0
+                            ],
+                            "times": [
+                                [
+                                    0,
+                                    0
+                                ],
+                                [
+                                    6,
+                                    0
+                                ],
+                                [
+                                    22,
+                                    0
+                                ]
+                            ],
+                            "interpolate": false
+                        },
+                        {
+                            "type": "ScheduleDay",
+                            "identifier": "OfficeMedium INFIL_SCH_PNNL_Sat_WntrDsn",
+                            "values": [
+                                1.0,
+                                0.25,
+                                1.0
+                            ],
+                            "times": [
+                                [
+                                    0,
+                                    0
+                                ],
+                                [
+                                    6,
+                                    0
+                                ],
+                                [
+                                    18,
+                                    0
+                                ]
+                            ],
+                            "interpolate": false
+                        },
+                        {
+                            "type": "ScheduleDay",
+                            "identifier": "OfficeMedium INFIL_SCH_PNNL_Wkdy",
+                            "values": [
+                                1.0,
+                                0.25,
+                                1.0
+                            ],
+                            "times": [
+                                [
+                                    0,
+                                    0
+                                ],
+                                [
+                                    6,
+                                    0
+                                ],
+                                [
+                                    22,
+                                    0
+                                ]
+                            ],
+                            "interpolate": false
+                        },
+                        {
+                            "type": "ScheduleDay",
+                            "identifier": "OfficeMedium INFIL_SCH_PNNL_Sat",
+                            "values": [
+                                1.0,
+                                0.25,
+                                1.0
+                            ],
+                            "times": [
+                                [
+                                    0,
+                                    0
+                                ],
+                                [
+                                    6,
+                                    0
+                                ],
+                                [
+                                    18,
+                                    0
+                                ]
+                            ],
+                            "interpolate": false
+                        }
+                    ],
+                    "default_day_schedule": "OfficeMedium INFIL_SCH_PNNL_Default",
+                    "schedule_rules": [
+                        {
+                            "type": "ScheduleRuleAbridged",
+                            "schedule_day": "OfficeMedium INFIL_SCH_PNNL_Wkdy",
+                            "apply_sunday": false,
+                            "apply_monday": true,
+                            "apply_tuesday": true,
+                            "apply_wednesday": true,
+                            "apply_thursday": true,
+                            "apply_friday": true,
+                            "apply_saturday": false,
+                            "start_date": [
+                                1,
+                                1
+                            ],
+                            "end_date": [
+                                12,
+                                31
+                            ]
+                        },
+                        {
+                            "type": "ScheduleRuleAbridged",
+                            "schedule_day": "OfficeMedium INFIL_SCH_PNNL_Sat",
+                            "apply_sunday": false,
+                            "apply_monday": false,
+                            "apply_tuesday": false,
+                            "apply_wednesday": false,
+                            "apply_thursday": false,
+                            "apply_friday": false,
+                            "apply_saturday": true,
+                            "start_date": [
+                                1,
+                                1
+                            ],
+                            "end_date": [
+                                12,
+                                31
+                            ]
+                        }
+                    ],
+                    "holiday_schedule": "OfficeMedium INFIL_SCH_PNNL_Default",
+                    "summer_designday_schedule": "OfficeMedium INFIL_SCH_PNNL_Wkdy_SmrDsn",
+                    "winter_designday_schedule": "OfficeMedium INFIL_SCH_PNNL_Sat_WntrDsn",
+                    "schedule_type_limit": "Fractional"
+                },
+                {
+                    "type": "ScheduleRulesetAbridged",
+                    "identifier": "Generic Office Equipment",
+                    "day_schedules": [
+                        {
+                            "type": "ScheduleDay",
+                            "identifier": "OfficeMedium BLDG_EQUIP_SCH_2013_Sun",
+                            "values": [
+                                0.2307553806,
+                                0.288107175,
+                                0.2307553806
+                            ],
+                            "times": [
+                                [
+                                    0,
+                                    0
+                                ],
+                                [
+                                    6,
+                                    0
+                                ],
+                                [
+                                    18,
+                                    0
+                                ]
+                            ],
+                            "interpolate": false
+                        },
+                        {
+                            "type": "ScheduleDay",
+                            "identifier": "OfficeMedium BLDG_EQUIP_SCH_2013_SmrDsn",
+                            "values": [
+                                1.0
+                            ],
+                            "times": [
+                                [
+                                    0,
+                                    0
+                                ]
+                            ],
+                            "interpolate": false
+                        },
+                        {
+                            "type": "ScheduleDay",
+                            "identifier": "OfficeMedium BLDG_EQUIP_SCH_2013_WntrDsn",
+                            "values": [
+                                0.0
+                            ],
+                            "times": [
+                                [
+                                    0,
+                                    0
+                                ]
+                            ],
+                            "interpolate": false
+                        },
+                        {
+                            "type": "ScheduleDay",
+                            "identifier": "OfficeMedium BLDG_EQUIP_SCH_2013_Sat",
+                            "values": [
+                                0.2307553806,
+                                0.381234796,
+                                0.476543495,
+                                0.3335804465,
+                                0.285926097,
+                                0.2307553806
+                            ],
+                            "times": [
+                                [
+                                    0,
+                                    0
+                                ],
+                                [
+                                    6,
+                                    0
+                                ],
+                                [
+                                    8,
+                                    0
+                                ],
+                                [
+                                    12,
+                                    0
+                                ],
+                                [
+                                    17,
+                                    0
+                                ],
+                                [
+                                    19,
+                                    0
+                                ]
+                            ],
+                            "interpolate": false
+                        },
+                        {
+                            "type": "ScheduleDay",
+                            "identifier": "OfficeMedium BLDG_EQUIP_SCH_2013_Wkdy",
+                            "values": [
+                                0.3076738408,
+                                0.381234796,
+                                0.857778291,
+                                0.762469592,
+                                0.857778291,
+                                0.476543495,
+                                0.381234796
+                            ],
+                            "times": [
+                                [
+                                    0,
+                                    0
+                                ],
+                                [
+                                    6,
+                                    0
+                                ],
+                                [
+                                    8,
+                                    0
+                                ],
+                                [
+                                    12,
+                                    0
+                                ],
+                                [
+                                    13,
+                                    0
+                                ],
+                                [
+                                    17,
+                                    0
+                                ],
+                                [
+                                    18,
+                                    0
+                                ]
+                            ],
+                            "interpolate": false
+                        }
+                    ],
+                    "default_day_schedule": "OfficeMedium BLDG_EQUIP_SCH_2013_Sun",
+                    "schedule_rules": [
+                        {
+                            "type": "ScheduleRuleAbridged",
+                            "schedule_day": "OfficeMedium BLDG_EQUIP_SCH_2013_Wkdy",
+                            "apply_sunday": false,
+                            "apply_monday": true,
+                            "apply_tuesday": true,
+                            "apply_wednesday": true,
+                            "apply_thursday": true,
+                            "apply_friday": true,
+                            "apply_saturday": false,
+                            "start_date": [
+                                1,
+                                1
+                            ],
+                            "end_date": [
+                                12,
+                                31
+                            ]
+                        },
+                        {
+                            "type": "ScheduleRuleAbridged",
+                            "schedule_day": "OfficeMedium BLDG_EQUIP_SCH_2013_Sat",
+                            "apply_sunday": false,
+                            "apply_monday": false,
+                            "apply_tuesday": false,
+                            "apply_wednesday": false,
+                            "apply_thursday": false,
+                            "apply_friday": false,
+                            "apply_saturday": true,
+                            "start_date": [
+                                1,
+                                1
+                            ],
+                            "end_date": [
+                                12,
+                                31
+                            ]
+                        }
+                    ],
+                    "holiday_schedule": "OfficeMedium BLDG_EQUIP_SCH_2013_Sat",
+                    "summer_designday_schedule": "OfficeMedium BLDG_EQUIP_SCH_2013_SmrDsn",
+                    "winter_designday_schedule": "OfficeMedium BLDG_EQUIP_SCH_2013_WntrDsn",
+                    "schedule_type_limit": "Fractional"
+                },
+                {
+                    "type": "ScheduleRulesetAbridged",
+                    "identifier": "Generic Office Lighting",
+                    "day_schedules": [
+                        {
+                            "type": "ScheduleDay",
+                            "identifier": "OfficeMedium BLDG_LIGHT_SCH_2013_Sun",
+                            "values": [
+                                0.05,
+                                0.04311628,
+                                0.05
+                            ],
+                            "times": [
+                                [
+                                    0,
+                                    0
+                                ],
+                                [
+                                    6,
+                                    0
+                                ],
+                                [
+                                    18,
+                                    0
+                                ]
+                            ],
+                            "interpolate": false
+                        },
+                        {
+                            "type": "ScheduleDay",
+                            "identifier": "OfficeMedium BLDG_LIGHT_SCH_2013_SmrDsn",
+                            "values": [
+                                1.0
+                            ],
+                            "times": [
+                                [
+                                    0,
+                                    0
+                                ]
+                            ],
+                            "interpolate": false
+                        },
+                        {
+                            "type": "ScheduleDay",
+                            "identifier": "OfficeMedium BLDG_LIGHT_SCH_2013_WntrDsn",
+                            "values": [
+                                0.0
+                            ],
+                            "times": [
+                                [
+                                    0,
+                                    0
+                                ]
+                            ],
+                            "interpolate": false
+                        },
+                        {
+                            "type": "ScheduleDay",
+                            "identifier": "OfficeMedium BLDG_LIGHT_SCH_2013_Sat",
+                            "values": [
+                                0.05,
+                                0.08623256,
+                                0.25869768,
+                                0.12934884,
+                                0.04311628,
+                                0.05
+                            ],
+                            "times": [
+                                [
+                                    0,
+                                    0
+                                ],
+                                [
+                                    6,
+                                    0
+                                ],
+                                [
+                                    8,
+                                    0
+                                ],
+                                [
+                                    12,
+                                    0
+                                ],
+                                [
+                                    17,
+                                    0
+                                ],
+                                [
+                                    19,
+                                    0
+                                ]
+                            ],
+                            "interpolate": false
+                        },
+                        {
+                            "type": "ScheduleDay",
+                            "identifier": "OfficeMedium BLDG_LIGHT_SCH_2013_Wkdy",
+                            "values": [
+                                0.05,
+                                0.1,
+                                0.08623256,
+                                0.25869768,
+                                0.77609304,
+                                0.4311628,
+                                0.25869768,
+                                0.17246512,
+                                0.08623256,
+                                0.04311628
+                            ],
+                            "times": [
+                                [
+                                    0,
+                                    0
+                                ],
+                                [
+                                    5,
+                                    0
+                                ],
+                                [
+                                    6,
+                                    0
+                                ],
+                                [
+                                    7,
+                                    0
+                                ],
+                                [
+                                    8,
+                                    0
+                                ],
+                                [
+                                    17,
+                                    0
+                                ],
+                                [
+                                    18,
+                                    0
+                                ],
+                                [
+                                    20,
+                                    0
+                                ],
+                                [
+                                    22,
+                                    0
+                                ],
+                                [
+                                    23,
+                                    0
+                                ]
+                            ],
+                            "interpolate": false
+                        }
+                    ],
+                    "default_day_schedule": "OfficeMedium BLDG_LIGHT_SCH_2013_Sun",
+                    "schedule_rules": [
+                        {
+                            "type": "ScheduleRuleAbridged",
+                            "schedule_day": "OfficeMedium BLDG_LIGHT_SCH_2013_Wkdy",
+                            "apply_sunday": false,
+                            "apply_monday": true,
+                            "apply_tuesday": true,
+                            "apply_wednesday": true,
+                            "apply_thursday": true,
+                            "apply_friday": true,
+                            "apply_saturday": false,
+                            "start_date": [
+                                1,
+                                1
+                            ],
+                            "end_date": [
+                                12,
+                                31
+                            ]
+                        },
+                        {
+                            "type": "ScheduleRuleAbridged",
+                            "schedule_day": "OfficeMedium BLDG_LIGHT_SCH_2013_Sat",
+                            "apply_sunday": false,
+                            "apply_monday": false,
+                            "apply_tuesday": false,
+                            "apply_wednesday": false,
+                            "apply_thursday": false,
+                            "apply_friday": false,
+                            "apply_saturday": true,
+                            "start_date": [
+                                1,
+                                1
+                            ],
+                            "end_date": [
+                                12,
+                                31
+                            ]
+                        }
+                    ],
+                    "holiday_schedule": "OfficeMedium BLDG_LIGHT_SCH_2013_Sat",
+                    "summer_designday_schedule": "OfficeMedium BLDG_LIGHT_SCH_2013_SmrDsn",
+                    "winter_designday_schedule": "OfficeMedium BLDG_LIGHT_SCH_2013_WntrDsn",
+                    "schedule_type_limit": "Fractional"
+                },
+                {
+                    "type": "ScheduleRulesetAbridged",
+                    "identifier": "Generic Office Occupancy",
+                    "day_schedules": [
+                        {
+                            "type": "ScheduleDay",
+                            "identifier": "OfficeMedium BLDG_OCC_SCH_Default",
+                            "values": [
+                                0.0,
+                                0.05,
+                                0.0
+                            ],
+                            "times": [
+                                [
+                                    0,
+                                    0
+                                ],
+                                [
+                                    6,
+                                    0
+                                ],
+                                [
+                                    18,
+                                    0
+                                ]
+                            ],
+                            "interpolate": false
+                        },
+                        {
+                            "type": "ScheduleDay",
+                            "identifier": "OfficeMedium BLDG_OCC_SCH_SmrDsn",
+                            "values": [
+                                0.0,
+                                1.0,
+                                0.05
+                            ],
+                            "times": [
+                                [
+                                    0,
+                                    0
+                                ],
+                                [
+                                    6,
+                                    0
+                                ],
+                                [
+                                    22,
+                                    0
+                                ]
+                            ],
+                            "interpolate": false
+                        },
+                        {
+                            "type": "ScheduleDay",
+                            "identifier": "OfficeMedium BLDG_OCC_SCH_WntrDsn",
+                            "values": [
+                                0.0
+                            ],
+                            "times": [
+                                [
+                                    0,
+                                    0
+                                ]
+                            ],
+                            "interpolate": false
+                        },
+                        {
+                            "type": "ScheduleDay",
+                            "identifier": "OfficeMedium BLDG_OCC_SCH_Wkdy",
+                            "values": [
+                                0.0,
+                                0.1,
+                                0.2,
+                                0.95,
+                                0.5,
+                                0.95,
+                                0.3,
+                                0.1,
+                                0.05
+                            ],
+                            "times": [
+                                [
+                                    0,
+                                    0
+                                ],
+                                [
+                                    6,
+                                    0
+                                ],
+                                [
+                                    7,
+                                    0
+                                ],
+                                [
+                                    8,
+                                    0
+                                ],
+                                [
+                                    12,
+                                    0
+                                ],
+                                [
+                                    13,
+                                    0
+                                ],
+                                [
+                                    17,
+                                    0
+                                ],
+                                [
+                                    18,
+                                    0
+                                ],
+                                [
+                                    22,
+                                    0
+                                ]
+                            ],
+                            "interpolate": false
+                        },
+                        {
+                            "type": "ScheduleDay",
+                            "identifier": "OfficeMedium BLDG_OCC_SCH_Sat",
+                            "values": [
+                                0.0,
+                                0.1,
+                                0.3,
+                                0.1,
+                                0.05,
+                                0.0
+                            ],
+                            "times": [
+                                [
+                                    0,
+                                    0
+                                ],
+                                [
+                                    6,
+                                    0
+                                ],
+                                [
+                                    8,
+                                    0
+                                ],
+                                [
+                                    12,
+                                    0
+                                ],
+                                [
+                                    17,
+                                    0
+                                ],
+                                [
+                                    19,
+                                    0
+                                ]
+                            ],
+                            "interpolate": false
+                        }
+                    ],
+                    "default_day_schedule": "OfficeMedium BLDG_OCC_SCH_Default",
+                    "schedule_rules": [
+                        {
+                            "type": "ScheduleRuleAbridged",
+                            "schedule_day": "OfficeMedium BLDG_OCC_SCH_Wkdy",
+                            "apply_sunday": false,
+                            "apply_monday": true,
+                            "apply_tuesday": true,
+                            "apply_wednesday": true,
+                            "apply_thursday": true,
+                            "apply_friday": true,
+                            "apply_saturday": false,
+                            "start_date": [
+                                1,
+                                1
+                            ],
+                            "end_date": [
+                                12,
+                                31
+                            ]
+                        },
+                        {
+                            "type": "ScheduleRuleAbridged",
+                            "schedule_day": "OfficeMedium BLDG_OCC_SCH_Sat",
+                            "apply_sunday": false,
+                            "apply_monday": false,
+                            "apply_tuesday": false,
+                            "apply_wednesday": false,
+                            "apply_thursday": false,
+                            "apply_friday": false,
+                            "apply_saturday": true,
+                            "start_date": [
+                                1,
+                                1
+                            ],
+                            "end_date": [
+                                12,
+                                31
+                            ]
+                        }
+                    ],
+                    "holiday_schedule": "OfficeMedium BLDG_OCC_SCH_Default",
+                    "summer_designday_schedule": "OfficeMedium BLDG_OCC_SCH_SmrDsn",
+                    "winter_designday_schedule": "OfficeMedium BLDG_OCC_SCH_WntrDsn",
+                    "schedule_type_limit": "Fractional"
+                }
+            ],
+            "schedule_type_limits": [
+                {
+                    "type": "ScheduleTypeLimit",
+                    "identifier": "Fractional",
+                    "lower_limit": 0.0,
+                    "upper_limit": 1.0,
+                    "numeric_type": "Continuous",
+                    "unit_type": "Dimensionless"
+                },
+                {
+                    "type": "ScheduleTypeLimit",
+                    "identifier": "Activity Level",
+                    "lower_limit": 0.0,
+                    "upper_limit": {
+                        "type": "NoLimit"
+                    },
+                    "numeric_type": "Continuous",
+                    "unit_type": "ActivityLevel"
+                },
+                {
+                    "type": "ScheduleTypeLimit",
+                    "identifier": "Temperature",
+                    "lower_limit": -273.15,
+                    "upper_limit": {
+                        "type": "NoLimit"
+                    },
+                    "numeric_type": "Continuous",
+                    "unit_type": "Temperature"
+                }
+            ]
+        }
+    },
+    "rooms": [
+        {
+            "type": "Room",
+            "identifier": "First_Floor",
+            "display_name": "First_Floor",
+            "properties": {
+                "type": "RoomPropertiesAbridged",
+                "energy": {
+                    "type": "RoomEnergyPropertiesAbridged",
+                    "program_type": "Generic Office Program",
+                    "hvac": "VAV System with Glycol Loop"
+                }
+            },
+            "faces": [
+                {
+                    "type": "Face",
+                    "identifier": "First_Floor_Bottom",
+                    "display_name": "First_Floor_Bottom",
+                    "properties": {
+                        "type": "FacePropertiesAbridged",
+                        "energy": {
+                            "type": "FaceEnergyPropertiesAbridged"
+                        }
+                    },
+                    "geometry": {
+                        "type": "Face3D",
+                        "boundary": [
+                            [
+                                0.0,
+                                0.0,
+                                0.0
+                            ],
+                            [
+                                0.0,
+                                10.0,
+                                0.0
+                            ],
+                            [
+                                10.0,
+                                10.0,
+                                0.0
+                            ],
+                            [
+                                10.0,
+                                0.0,
+                                0.0
+                            ]
+                        ]
+                    },
+                    "face_type": "Floor",
+                    "boundary_condition": {
+                        "type": "Ground"
+                    }
+                },
+                {
+                    "type": "Face",
+                    "identifier": "First_Floor_Front",
+                    "display_name": "First_Floor_Front",
+                    "properties": {
+                        "type": "FacePropertiesAbridged",
+                        "energy": {
+                            "type": "FaceEnergyPropertiesAbridged"
+                        }
+                    },
+                    "geometry": {
+                        "type": "Face3D",
+                        "boundary": [
+                            [
+                                10.0,
+                                10.0,
+                                3.0
+                            ],
+                            [
+                                10.0,
+                                10.0,
+                                0.0
+                            ],
+                            [
+                                0.0,
+                                10.0,
+                                0.0
+                            ],
+                            [
+                                0.0,
+                                10.0,
+                                3.0
+                            ]
+                        ]
+                    },
+                    "face_type": "Wall",
+                    "boundary_condition": {
+                        "type": "Outdoors",
+                        "sun_exposure": true,
+                        "wind_exposure": true,
+                        "view_factor": {
+                            "type": "Autocalculate"
+                        }
+                    },
+                    "apertures": [
+                        {
+                            "type": "Aperture",
+                            "identifier": "First_Floor_Front_Glz0",
+                            "display_name": "First_Floor_Front_Glz0",
+                            "properties": {
+                                "type": "AperturePropertiesAbridged",
+                                "energy": {
+                                    "type": "ApertureEnergyPropertiesAbridged"
+                                }
+                            },
+                            "geometry": {
+                                "type": "Face3D",
+                                "boundary": [
+                                    [
+                                        7.23606797749979,
+                                        10.0,
+                                        2.170820393249937
+                                    ],
+                                    [
+                                        7.23606797749979,
+                                        10.0,
+                                        0.8291796067500631
+                                    ],
+                                    [
+                                        2.76393202250021,
+                                        10.0,
+                                        0.8291796067500631
+                                    ],
+                                    [
+                                        2.76393202250021,
+                                        10.0,
+                                        2.170820393249937
+                                    ]
+                                ]
+                            },
+                            "is_operable": false,
+                            "boundary_condition": {
+                                "type": "Outdoors",
+                                "sun_exposure": true,
+                                "wind_exposure": true,
+                                "view_factor": {
+                                    "type": "Autocalculate"
+                                }
+                            }
+                        }
+                    ]
+                },
+                {
+                    "type": "Face",
+                    "identifier": "First_Floor_Right",
+                    "display_name": "First_Floor_Right",
+                    "properties": {
+                        "type": "FacePropertiesAbridged",
+                        "energy": {
+                            "type": "FaceEnergyPropertiesAbridged"
+                        }
+                    },
+                    "geometry": {
+                        "type": "Face3D",
+                        "boundary": [
+                            [
+                                10.0,
+                                0.0,
+                                3.0
+                            ],
+                            [
+                                10.0,
+                                0.0,
+                                0.0
+                            ],
+                            [
+                                10.0,
+                                10.0,
+                                0.0
+                            ],
+                            [
+                                10.0,
+                                10.0,
+                                3.0
+                            ]
+                        ]
+                    },
+                    "face_type": "Wall",
+                    "boundary_condition": {
+                        "type": "Outdoors",
+                        "sun_exposure": true,
+                        "wind_exposure": true,
+                        "view_factor": {
+                            "type": "Autocalculate"
+                        }
+                    },
+                    "apertures": [
+                        {
+                            "type": "Aperture",
+                            "identifier": "First_Floor_Right_Glz0",
+                            "display_name": "First_Floor_Right_Glz0",
+                            "properties": {
+                                "type": "AperturePropertiesAbridged",
+                                "energy": {
+                                    "type": "ApertureEnergyPropertiesAbridged"
+                                }
+                            },
+                            "geometry": {
+                                "type": "Face3D",
+                                "boundary": [
+                                    [
+                                        10.0,
+                                        2.76393202250021,
+                                        2.170820393249937
+                                    ],
+                                    [
+                                        10.0,
+                                        2.76393202250021,
+                                        0.8291796067500631
+                                    ],
+                                    [
+                                        10.0,
+                                        7.23606797749979,
+                                        0.8291796067500631
+                                    ],
+                                    [
+                                        10.0,
+                                        7.23606797749979,
+                                        2.170820393249937
+                                    ]
+                                ]
+                            },
+                            "is_operable": false,
+                            "boundary_condition": {
+                                "type": "Outdoors",
+                                "sun_exposure": true,
+                                "wind_exposure": true,
+                                "view_factor": {
+                                    "type": "Autocalculate"
+                                }
+                            }
+                        }
+                    ]
+                },
+                {
+                    "type": "Face",
+                    "identifier": "First_Floor_Back",
+                    "display_name": "First_Floor_Back",
+                    "properties": {
+                        "type": "FacePropertiesAbridged",
+                        "energy": {
+                            "type": "FaceEnergyPropertiesAbridged"
+                        }
+                    },
+                    "geometry": {
+                        "type": "Face3D",
+                        "boundary": [
+                            [
+                                0.0,
+                                0.0,
+                                3.0
+                            ],
+                            [
+                                0.0,
+                                0.0,
+                                0.0
+                            ],
+                            [
+                                10.0,
+                                0.0,
+                                0.0
+                            ],
+                            [
+                                10.0,
+                                0.0,
+                                3.0
+                            ]
+                        ]
+                    },
+                    "face_type": "Wall",
+                    "boundary_condition": {
+                        "type": "Outdoors",
+                        "sun_exposure": true,
+                        "wind_exposure": true,
+                        "view_factor": {
+                            "type": "Autocalculate"
+                        }
+                    },
+                    "apertures": [
+                        {
+                            "type": "Aperture",
+                            "identifier": "First_Floor_Back_Glz0",
+                            "display_name": "First_Floor_Back_Glz0",
+                            "properties": {
+                                "type": "AperturePropertiesAbridged",
+                                "energy": {
+                                    "type": "ApertureEnergyPropertiesAbridged"
+                                }
+                            },
+                            "geometry": {
+                                "type": "Face3D",
+                                "boundary": [
+                                    [
+                                        2.76393202250021,
+                                        0.0,
+                                        2.170820393249937
+                                    ],
+                                    [
+                                        2.76393202250021,
+                                        0.0,
+                                        0.8291796067500631
+                                    ],
+                                    [
+                                        7.23606797749979,
+                                        0.0,
+                                        0.8291796067500631
+                                    ],
+                                    [
+                                        7.23606797749979,
+                                        0.0,
+                                        2.170820393249937
+                                    ]
+                                ]
+                            },
+                            "is_operable": false,
+                            "boundary_condition": {
+                                "type": "Outdoors",
+                                "sun_exposure": true,
+                                "wind_exposure": true,
+                                "view_factor": {
+                                    "type": "Autocalculate"
+                                }
+                            }
+                        }
+                    ]
+                },
+                {
+                    "type": "Face",
+                    "identifier": "First_Floor_Left",
+                    "display_name": "First_Floor_Left",
+                    "properties": {
+                        "type": "FacePropertiesAbridged",
+                        "energy": {
+                            "type": "FaceEnergyPropertiesAbridged"
+                        }
+                    },
+                    "geometry": {
+                        "type": "Face3D",
+                        "boundary": [
+                            [
+                                0.0,
+                                10.0,
+                                3.0
+                            ],
+                            [
+                                0.0,
+                                10.0,
+                                0.0
+                            ],
+                            [
+                                0.0,
+                                0.0,
+                                0.0
+                            ],
+                            [
+                                0.0,
+                                0.0,
+                                3.0
+                            ]
+                        ]
+                    },
+                    "face_type": "Wall",
+                    "boundary_condition": {
+                        "type": "Outdoors",
+                        "sun_exposure": true,
+                        "wind_exposure": true,
+                        "view_factor": {
+                            "type": "Autocalculate"
+                        }
+                    },
+                    "apertures": [
+                        {
+                            "type": "Aperture",
+                            "identifier": "First_Floor_Left_Glz0",
+                            "display_name": "First_Floor_Left_Glz0",
+                            "properties": {
+                                "type": "AperturePropertiesAbridged",
+                                "energy": {
+                                    "type": "ApertureEnergyPropertiesAbridged"
+                                }
+                            },
+                            "geometry": {
+                                "type": "Face3D",
+                                "boundary": [
+                                    [
+                                        0.0,
+                                        7.23606797749979,
+                                        2.170820393249937
+                                    ],
+                                    [
+                                        0.0,
+                                        7.23606797749979,
+                                        0.8291796067500631
+                                    ],
+                                    [
+                                        0.0,
+                                        2.76393202250021,
+                                        0.8291796067500631
+                                    ],
+                                    [
+                                        0.0,
+                                        2.76393202250021,
+                                        2.170820393249937
+                                    ]
+                                ]
+                            },
+                            "is_operable": false,
+                            "boundary_condition": {
+                                "type": "Outdoors",
+                                "sun_exposure": true,
+                                "wind_exposure": true,
+                                "view_factor": {
+                                    "type": "Autocalculate"
+                                }
+                            }
+                        }
+                    ]
+                },
+                {
+                    "type": "Face",
+                    "identifier": "First_Floor_Top",
+                    "display_name": "First_Floor_Top",
+                    "properties": {
+                        "type": "FacePropertiesAbridged",
+                        "energy": {
+                            "type": "FaceEnergyPropertiesAbridged"
+                        }
+                    },
+                    "geometry": {
+                        "type": "Face3D",
+                        "boundary": [
+                            [
+                                10.0,
+                                0.0,
+                                3.0
+                            ],
+                            [
+                                10.0,
+                                10.0,
+                                3.0
+                            ],
+                            [
+                                0.0,
+                                10.0,
+                                3.0
+                            ],
+                            [
+                                0.0,
+                                0.0,
+                                3.0
+                            ]
+                        ]
+                    },
+                    "face_type": "RoofCeiling",
+                    "boundary_condition": {
+                        "type": "Surface",
+                        "boundary_condition_objects": [
+                            "Second_Floor_Bottom",
+                            "Second_Floor"
+                        ]
+                    }
+                }
+            ]
+        },
+        {
+            "type": "Room",
+            "identifier": "Second_Floor",
+            "display_name": "Second_Floor",
+            "properties": {
+                "type": "RoomPropertiesAbridged",
+                "energy": {
+                    "type": "RoomEnergyPropertiesAbridged",
+                    "program_type": "Generic Office Program",
+                    "hvac": "VAV System with Glycol Loop"
+                }
+            },
+            "faces": [
+                {
+                    "type": "Face",
+                    "identifier": "Second_Floor_Bottom",
+                    "display_name": "Second_Floor_Bottom",
+                    "properties": {
+                        "type": "FacePropertiesAbridged",
+                        "energy": {
+                            "type": "FaceEnergyPropertiesAbridged"
+                        }
+                    },
+                    "geometry": {
+                        "type": "Face3D",
+                        "boundary": [
+                            [
+                                0.0,
+                                0.0,
+                                3.0
+                            ],
+                            [
+                                0.0,
+                                10.0,
+                                3.0
+                            ],
+                            [
+                                10.0,
+                                10.0,
+                                3.0
+                            ],
+                            [
+                                10.0,
+                                0.0,
+                                3.0
+                            ]
+                        ]
+                    },
+                    "face_type": "Floor",
+                    "boundary_condition": {
+                        "type": "Surface",
+                        "boundary_condition_objects": [
+                            "First_Floor_Top",
+                            "First_Floor"
+                        ]
+                    }
+                },
+                {
+                    "type": "Face",
+                    "identifier": "Second_Floor_Front",
+                    "display_name": "Second_Floor_Front",
+                    "properties": {
+                        "type": "FacePropertiesAbridged",
+                        "energy": {
+                            "type": "FaceEnergyPropertiesAbridged"
+                        }
+                    },
+                    "geometry": {
+                        "type": "Face3D",
+                        "boundary": [
+                            [
+                                10.0,
+                                10.0,
+                                6.0
+                            ],
+                            [
+                                10.0,
+                                10.0,
+                                3.0
+                            ],
+                            [
+                                0.0,
+                                10.0,
+                                3.0
+                            ],
+                            [
+                                0.0,
+                                10.0,
+                                6.0
+                            ]
+                        ]
+                    },
+                    "face_type": "Wall",
+                    "boundary_condition": {
+                        "type": "Outdoors",
+                        "sun_exposure": true,
+                        "wind_exposure": true,
+                        "view_factor": {
+                            "type": "Autocalculate"
+                        }
+                    },
+                    "apertures": [
+                        {
+                            "type": "Aperture",
+                            "identifier": "Second_Floor_Front_Glz0",
+                            "display_name": "Second_Floor_Front_Glz0",
+                            "properties": {
+                                "type": "AperturePropertiesAbridged",
+                                "energy": {
+                                    "type": "ApertureEnergyPropertiesAbridged"
+                                }
+                            },
+                            "geometry": {
+                                "type": "Face3D",
+                                "boundary": [
+                                    [
+                                        7.23606797749979,
+                                        10.0,
+                                        5.170820393249937
+                                    ],
+                                    [
+                                        7.23606797749979,
+                                        10.0,
+                                        3.829179606750063
+                                    ],
+                                    [
+                                        2.76393202250021,
+                                        10.0,
+                                        3.829179606750063
+                                    ],
+                                    [
+                                        2.76393202250021,
+                                        10.0,
+                                        5.170820393249937
+                                    ]
+                                ]
+                            },
+                            "is_operable": false,
+                            "boundary_condition": {
+                                "type": "Outdoors",
+                                "sun_exposure": true,
+                                "wind_exposure": true,
+                                "view_factor": {
+                                    "type": "Autocalculate"
+                                }
+                            }
+                        }
+                    ]
+                },
+                {
+                    "type": "Face",
+                    "identifier": "Second_Floor_Right",
+                    "display_name": "Second_Floor_Right",
+                    "properties": {
+                        "type": "FacePropertiesAbridged",
+                        "energy": {
+                            "type": "FaceEnergyPropertiesAbridged"
+                        }
+                    },
+                    "geometry": {
+                        "type": "Face3D",
+                        "boundary": [
+                            [
+                                10.0,
+                                0.0,
+                                6.0
+                            ],
+                            [
+                                10.0,
+                                0.0,
+                                3.0
+                            ],
+                            [
+                                10.0,
+                                10.0,
+                                3.0
+                            ],
+                            [
+                                10.0,
+                                10.0,
+                                6.0
+                            ]
+                        ]
+                    },
+                    "face_type": "Wall",
+                    "boundary_condition": {
+                        "type": "Outdoors",
+                        "sun_exposure": true,
+                        "wind_exposure": true,
+                        "view_factor": {
+                            "type": "Autocalculate"
+                        }
+                    },
+                    "apertures": [
+                        {
+                            "type": "Aperture",
+                            "identifier": "Second_Floor_Right_Glz0",
+                            "display_name": "Second_Floor_Right_Glz0",
+                            "properties": {
+                                "type": "AperturePropertiesAbridged",
+                                "energy": {
+                                    "type": "ApertureEnergyPropertiesAbridged"
+                                }
+                            },
+                            "geometry": {
+                                "type": "Face3D",
+                                "boundary": [
+                                    [
+                                        10.0,
+                                        2.76393202250021,
+                                        5.170820393249937
+                                    ],
+                                    [
+                                        10.0,
+                                        2.76393202250021,
+                                        3.829179606750063
+                                    ],
+                                    [
+                                        10.0,
+                                        7.23606797749979,
+                                        3.829179606750063
+                                    ],
+                                    [
+                                        10.0,
+                                        7.23606797749979,
+                                        5.170820393249937
+                                    ]
+                                ]
+                            },
+                            "is_operable": false,
+                            "boundary_condition": {
+                                "type": "Outdoors",
+                                "sun_exposure": true,
+                                "wind_exposure": true,
+                                "view_factor": {
+                                    "type": "Autocalculate"
+                                }
+                            }
+                        }
+                    ]
+                },
+                {
+                    "type": "Face",
+                    "identifier": "Second_Floor_Back",
+                    "display_name": "Second_Floor_Back",
+                    "properties": {
+                        "type": "FacePropertiesAbridged",
+                        "energy": {
+                            "type": "FaceEnergyPropertiesAbridged"
+                        }
+                    },
+                    "geometry": {
+                        "type": "Face3D",
+                        "boundary": [
+                            [
+                                0.0,
+                                0.0,
+                                6.0
+                            ],
+                            [
+                                0.0,
+                                0.0,
+                                3.0
+                            ],
+                            [
+                                10.0,
+                                0.0,
+                                3.0
+                            ],
+                            [
+                                10.0,
+                                0.0,
+                                6.0
+                            ]
+                        ]
+                    },
+                    "face_type": "Wall",
+                    "boundary_condition": {
+                        "type": "Outdoors",
+                        "sun_exposure": true,
+                        "wind_exposure": true,
+                        "view_factor": {
+                            "type": "Autocalculate"
+                        }
+                    },
+                    "apertures": [
+                        {
+                            "type": "Aperture",
+                            "identifier": "Second_Floor_Back_Glz0",
+                            "display_name": "Second_Floor_Back_Glz0",
+                            "properties": {
+                                "type": "AperturePropertiesAbridged",
+                                "energy": {
+                                    "type": "ApertureEnergyPropertiesAbridged"
+                                }
+                            },
+                            "geometry": {
+                                "type": "Face3D",
+                                "boundary": [
+                                    [
+                                        2.76393202250021,
+                                        0.0,
+                                        5.170820393249937
+                                    ],
+                                    [
+                                        2.76393202250021,
+                                        0.0,
+                                        3.829179606750063
+                                    ],
+                                    [
+                                        7.23606797749979,
+                                        0.0,
+                                        3.829179606750063
+                                    ],
+                                    [
+                                        7.23606797749979,
+                                        0.0,
+                                        5.170820393249937
+                                    ]
+                                ]
+                            },
+                            "is_operable": false,
+                            "boundary_condition": {
+                                "type": "Outdoors",
+                                "sun_exposure": true,
+                                "wind_exposure": true,
+                                "view_factor": {
+                                    "type": "Autocalculate"
+                                }
+                            }
+                        }
+                    ]
+                },
+                {
+                    "type": "Face",
+                    "identifier": "Second_Floor_Left",
+                    "display_name": "Second_Floor_Left",
+                    "properties": {
+                        "type": "FacePropertiesAbridged",
+                        "energy": {
+                            "type": "FaceEnergyPropertiesAbridged"
+                        }
+                    },
+                    "geometry": {
+                        "type": "Face3D",
+                        "boundary": [
+                            [
+                                0.0,
+                                10.0,
+                                6.0
+                            ],
+                            [
+                                0.0,
+                                10.0,
+                                3.0
+                            ],
+                            [
+                                0.0,
+                                0.0,
+                                3.0
+                            ],
+                            [
+                                0.0,
+                                0.0,
+                                6.0
+                            ]
+                        ]
+                    },
+                    "face_type": "Wall",
+                    "boundary_condition": {
+                        "type": "Outdoors",
+                        "sun_exposure": true,
+                        "wind_exposure": true,
+                        "view_factor": {
+                            "type": "Autocalculate"
+                        }
+                    },
+                    "apertures": [
+                        {
+                            "type": "Aperture",
+                            "identifier": "Second_Floor_Left_Glz0",
+                            "display_name": "Second_Floor_Left_Glz0",
+                            "properties": {
+                                "type": "AperturePropertiesAbridged",
+                                "energy": {
+                                    "type": "ApertureEnergyPropertiesAbridged"
+                                }
+                            },
+                            "geometry": {
+                                "type": "Face3D",
+                                "boundary": [
+                                    [
+                                        0.0,
+                                        7.23606797749979,
+                                        5.170820393249937
+                                    ],
+                                    [
+                                        0.0,
+                                        7.23606797749979,
+                                        3.829179606750063
+                                    ],
+                                    [
+                                        0.0,
+                                        2.76393202250021,
+                                        3.829179606750063
+                                    ],
+                                    [
+                                        0.0,
+                                        2.76393202250021,
+                                        5.170820393249937
+                                    ]
+                                ]
+                            },
+                            "is_operable": false,
+                            "boundary_condition": {
+                                "type": "Outdoors",
+                                "sun_exposure": true,
+                                "wind_exposure": true,
+                                "view_factor": {
+                                    "type": "Autocalculate"
+                                }
+                            }
+                        }
+                    ]
+                },
+                {
+                    "type": "Face",
+                    "identifier": "Second_Floor_Top",
+                    "display_name": "Second_Floor_Top",
+                    "properties": {
+                        "type": "FacePropertiesAbridged",
+                        "energy": {
+                            "type": "FaceEnergyPropertiesAbridged"
+                        }
+                    },
+                    "geometry": {
+                        "type": "Face3D",
+                        "boundary": [
+                            [
+                                10.0,
+                                0.0,
+                                6.0
+                            ],
+                            [
+                                10.0,
+                                10.0,
+                                6.0
+                            ],
+                            [
+                                0.0,
+                                10.0,
+                                6.0
+                            ],
+                            [
+                                0.0,
+                                0.0,
+                                6.0
+                            ]
+                        ]
+                    },
+                    "face_type": "RoofCeiling",
+                    "boundary_condition": {
+                        "type": "Outdoors",
+                        "sun_exposure": true,
+                        "wind_exposure": true,
+                        "view_factor": {
+                            "type": "Autocalculate"
+                        }
+                    }
+                }
+            ]
+        }
+    ],
+    "version": "1.35.1"
+}

--- a/samples/model/model_energy_doas_hvac.json
+++ b/samples/model/model_energy_doas_hvac.json
@@ -1,0 +1,2190 @@
+{
+    "type": "Model",
+    "identifier": "Model_Energy_DOAS_HVAC",
+    "display_name": "Model_Energy_DOAS_HVAC",
+    "units": "Meters",
+    "properties": {
+        "type": "ModelProperties",
+        "energy": {
+            "type": "ModelEnergyProperties",
+            "construction_sets": [],
+            "constructions": [],
+            "materials": [],
+            "hvacs": [
+                {
+                    "type": "FCUwithDOAS",
+                    "identifier": "FCU System with DOAS Enthalpy Wheel",
+                    "vintage": "90.1-2013",
+                    "equipment_type": "DOAS with fan coil chiller with boiler",
+                    "sensible_heat_recovery": 0.81,
+                    "latent_heat_recovery": 0.67
+                }
+            ],
+            "program_types": [
+                {
+                    "type": "ProgramTypeAbridged",
+                    "identifier": "Generic Office Program",
+                    "people": {
+                        "type": "PeopleAbridged",
+                        "identifier": "Generic Office People",
+                        "people_per_area": 0.0565,
+                        "radiant_fraction": 0.3,
+                        "latent_fraction": {
+                            "type": "Autocalculate"
+                        },
+                        "occupancy_schedule": "Generic Office Occupancy",
+                        "activity_schedule": "Seated Adult Activity"
+                    },
+                    "lighting": {
+                        "type": "LightingAbridged",
+                        "identifier": "Generic Office Lighting",
+                        "watts_per_area": 10.55,
+                        "return_air_fraction": 0.0,
+                        "radiant_fraction": 0.7,
+                        "visible_fraction": 0.2,
+                        "schedule": "Generic Office Lighting"
+                    },
+                    "electric_equipment": {
+                        "type": "ElectricEquipmentAbridged",
+                        "identifier": "Generic Office Equipment",
+                        "watts_per_area": 10.33,
+                        "radiant_fraction": 0.5,
+                        "latent_fraction": 0.0,
+                        "lost_fraction": 0.0,
+                        "schedule": "Generic Office Equipment"
+                    },
+                    "infiltration": {
+                        "type": "InfiltrationAbridged",
+                        "identifier": "Generic Office Infiltration",
+                        "flow_per_exterior_area": 0.0002266,
+                        "schedule": "Generic Office Infiltration"
+                    },
+                    "ventilation": {
+                        "type": "VentilationAbridged",
+                        "identifier": "Generic Office Ventilation",
+                        "flow_per_person": 0.00236,
+                        "flow_per_area": 0.000305
+                    },
+                    "setpoint": {
+                        "type": "SetpointAbridged",
+                        "identifier": "Generic Office Setpoints",
+                        "heating_schedule": "Generic Office Heating",
+                        "cooling_schedule": "Generic Office Cooling"
+                    }
+                }
+            ],
+            "schedules": [
+                {
+                    "type": "ScheduleRulesetAbridged",
+                    "identifier": "Generic Office Lighting",
+                    "day_schedules": [
+                        {
+                            "type": "ScheduleDay",
+                            "identifier": "OfficeMedium BLDG_LIGHT_SCH_2013_Sun",
+                            "values": [
+                                0.05,
+                                0.04311628,
+                                0.05
+                            ],
+                            "times": [
+                                [
+                                    0,
+                                    0
+                                ],
+                                [
+                                    6,
+                                    0
+                                ],
+                                [
+                                    18,
+                                    0
+                                ]
+                            ],
+                            "interpolate": false
+                        },
+                        {
+                            "type": "ScheduleDay",
+                            "identifier": "OfficeMedium BLDG_LIGHT_SCH_2013_SmrDsn",
+                            "values": [
+                                1.0
+                            ],
+                            "times": [
+                                [
+                                    0,
+                                    0
+                                ]
+                            ],
+                            "interpolate": false
+                        },
+                        {
+                            "type": "ScheduleDay",
+                            "identifier": "OfficeMedium BLDG_LIGHT_SCH_2013_WntrDsn",
+                            "values": [
+                                0.0
+                            ],
+                            "times": [
+                                [
+                                    0,
+                                    0
+                                ]
+                            ],
+                            "interpolate": false
+                        },
+                        {
+                            "type": "ScheduleDay",
+                            "identifier": "OfficeMedium BLDG_LIGHT_SCH_2013_Sat",
+                            "values": [
+                                0.05,
+                                0.08623256,
+                                0.25869768,
+                                0.12934884,
+                                0.04311628,
+                                0.05
+                            ],
+                            "times": [
+                                [
+                                    0,
+                                    0
+                                ],
+                                [
+                                    6,
+                                    0
+                                ],
+                                [
+                                    8,
+                                    0
+                                ],
+                                [
+                                    12,
+                                    0
+                                ],
+                                [
+                                    17,
+                                    0
+                                ],
+                                [
+                                    19,
+                                    0
+                                ]
+                            ],
+                            "interpolate": false
+                        },
+                        {
+                            "type": "ScheduleDay",
+                            "identifier": "OfficeMedium BLDG_LIGHT_SCH_2013_Wkdy",
+                            "values": [
+                                0.05,
+                                0.1,
+                                0.08623256,
+                                0.25869768,
+                                0.77609304,
+                                0.4311628,
+                                0.25869768,
+                                0.17246512,
+                                0.08623256,
+                                0.04311628
+                            ],
+                            "times": [
+                                [
+                                    0,
+                                    0
+                                ],
+                                [
+                                    5,
+                                    0
+                                ],
+                                [
+                                    6,
+                                    0
+                                ],
+                                [
+                                    7,
+                                    0
+                                ],
+                                [
+                                    8,
+                                    0
+                                ],
+                                [
+                                    17,
+                                    0
+                                ],
+                                [
+                                    18,
+                                    0
+                                ],
+                                [
+                                    20,
+                                    0
+                                ],
+                                [
+                                    22,
+                                    0
+                                ],
+                                [
+                                    23,
+                                    0
+                                ]
+                            ],
+                            "interpolate": false
+                        }
+                    ],
+                    "default_day_schedule": "OfficeMedium BLDG_LIGHT_SCH_2013_Sun",
+                    "schedule_rules": [
+                        {
+                            "type": "ScheduleRuleAbridged",
+                            "schedule_day": "OfficeMedium BLDG_LIGHT_SCH_2013_Wkdy",
+                            "apply_sunday": false,
+                            "apply_monday": true,
+                            "apply_tuesday": true,
+                            "apply_wednesday": true,
+                            "apply_thursday": true,
+                            "apply_friday": true,
+                            "apply_saturday": false,
+                            "start_date": [
+                                1,
+                                1
+                            ],
+                            "end_date": [
+                                12,
+                                31
+                            ]
+                        },
+                        {
+                            "type": "ScheduleRuleAbridged",
+                            "schedule_day": "OfficeMedium BLDG_LIGHT_SCH_2013_Sat",
+                            "apply_sunday": false,
+                            "apply_monday": false,
+                            "apply_tuesday": false,
+                            "apply_wednesday": false,
+                            "apply_thursday": false,
+                            "apply_friday": false,
+                            "apply_saturday": true,
+                            "start_date": [
+                                1,
+                                1
+                            ],
+                            "end_date": [
+                                12,
+                                31
+                            ]
+                        }
+                    ],
+                    "holiday_schedule": "OfficeMedium BLDG_LIGHT_SCH_2013_Sat",
+                    "summer_designday_schedule": "OfficeMedium BLDG_LIGHT_SCH_2013_SmrDsn",
+                    "winter_designday_schedule": "OfficeMedium BLDG_LIGHT_SCH_2013_WntrDsn",
+                    "schedule_type_limit": "Fractional"
+                },
+                {
+                    "type": "ScheduleRulesetAbridged",
+                    "identifier": "Generic Office Occupancy",
+                    "day_schedules": [
+                        {
+                            "type": "ScheduleDay",
+                            "identifier": "OfficeMedium BLDG_OCC_SCH_Default",
+                            "values": [
+                                0.0,
+                                0.05,
+                                0.0
+                            ],
+                            "times": [
+                                [
+                                    0,
+                                    0
+                                ],
+                                [
+                                    6,
+                                    0
+                                ],
+                                [
+                                    18,
+                                    0
+                                ]
+                            ],
+                            "interpolate": false
+                        },
+                        {
+                            "type": "ScheduleDay",
+                            "identifier": "OfficeMedium BLDG_OCC_SCH_SmrDsn",
+                            "values": [
+                                0.0,
+                                1.0,
+                                0.05
+                            ],
+                            "times": [
+                                [
+                                    0,
+                                    0
+                                ],
+                                [
+                                    6,
+                                    0
+                                ],
+                                [
+                                    22,
+                                    0
+                                ]
+                            ],
+                            "interpolate": false
+                        },
+                        {
+                            "type": "ScheduleDay",
+                            "identifier": "OfficeMedium BLDG_OCC_SCH_WntrDsn",
+                            "values": [
+                                0.0
+                            ],
+                            "times": [
+                                [
+                                    0,
+                                    0
+                                ]
+                            ],
+                            "interpolate": false
+                        },
+                        {
+                            "type": "ScheduleDay",
+                            "identifier": "OfficeMedium BLDG_OCC_SCH_Wkdy",
+                            "values": [
+                                0.0,
+                                0.1,
+                                0.2,
+                                0.95,
+                                0.5,
+                                0.95,
+                                0.3,
+                                0.1,
+                                0.05
+                            ],
+                            "times": [
+                                [
+                                    0,
+                                    0
+                                ],
+                                [
+                                    6,
+                                    0
+                                ],
+                                [
+                                    7,
+                                    0
+                                ],
+                                [
+                                    8,
+                                    0
+                                ],
+                                [
+                                    12,
+                                    0
+                                ],
+                                [
+                                    13,
+                                    0
+                                ],
+                                [
+                                    17,
+                                    0
+                                ],
+                                [
+                                    18,
+                                    0
+                                ],
+                                [
+                                    22,
+                                    0
+                                ]
+                            ],
+                            "interpolate": false
+                        },
+                        {
+                            "type": "ScheduleDay",
+                            "identifier": "OfficeMedium BLDG_OCC_SCH_Sat",
+                            "values": [
+                                0.0,
+                                0.1,
+                                0.3,
+                                0.1,
+                                0.05,
+                                0.0
+                            ],
+                            "times": [
+                                [
+                                    0,
+                                    0
+                                ],
+                                [
+                                    6,
+                                    0
+                                ],
+                                [
+                                    8,
+                                    0
+                                ],
+                                [
+                                    12,
+                                    0
+                                ],
+                                [
+                                    17,
+                                    0
+                                ],
+                                [
+                                    19,
+                                    0
+                                ]
+                            ],
+                            "interpolate": false
+                        }
+                    ],
+                    "default_day_schedule": "OfficeMedium BLDG_OCC_SCH_Default",
+                    "schedule_rules": [
+                        {
+                            "type": "ScheduleRuleAbridged",
+                            "schedule_day": "OfficeMedium BLDG_OCC_SCH_Wkdy",
+                            "apply_sunday": false,
+                            "apply_monday": true,
+                            "apply_tuesday": true,
+                            "apply_wednesday": true,
+                            "apply_thursday": true,
+                            "apply_friday": true,
+                            "apply_saturday": false,
+                            "start_date": [
+                                1,
+                                1
+                            ],
+                            "end_date": [
+                                12,
+                                31
+                            ]
+                        },
+                        {
+                            "type": "ScheduleRuleAbridged",
+                            "schedule_day": "OfficeMedium BLDG_OCC_SCH_Sat",
+                            "apply_sunday": false,
+                            "apply_monday": false,
+                            "apply_tuesday": false,
+                            "apply_wednesday": false,
+                            "apply_thursday": false,
+                            "apply_friday": false,
+                            "apply_saturday": true,
+                            "start_date": [
+                                1,
+                                1
+                            ],
+                            "end_date": [
+                                12,
+                                31
+                            ]
+                        }
+                    ],
+                    "holiday_schedule": "OfficeMedium BLDG_OCC_SCH_Default",
+                    "summer_designday_schedule": "OfficeMedium BLDG_OCC_SCH_SmrDsn",
+                    "winter_designday_schedule": "OfficeMedium BLDG_OCC_SCH_WntrDsn",
+                    "schedule_type_limit": "Fractional"
+                },
+                {
+                    "type": "ScheduleRulesetAbridged",
+                    "identifier": "Generic Office Equipment",
+                    "day_schedules": [
+                        {
+                            "type": "ScheduleDay",
+                            "identifier": "OfficeMedium BLDG_EQUIP_SCH_2013_Sun",
+                            "values": [
+                                0.2307553806,
+                                0.288107175,
+                                0.2307553806
+                            ],
+                            "times": [
+                                [
+                                    0,
+                                    0
+                                ],
+                                [
+                                    6,
+                                    0
+                                ],
+                                [
+                                    18,
+                                    0
+                                ]
+                            ],
+                            "interpolate": false
+                        },
+                        {
+                            "type": "ScheduleDay",
+                            "identifier": "OfficeMedium BLDG_EQUIP_SCH_2013_SmrDsn",
+                            "values": [
+                                1.0
+                            ],
+                            "times": [
+                                [
+                                    0,
+                                    0
+                                ]
+                            ],
+                            "interpolate": false
+                        },
+                        {
+                            "type": "ScheduleDay",
+                            "identifier": "OfficeMedium BLDG_EQUIP_SCH_2013_WntrDsn",
+                            "values": [
+                                0.0
+                            ],
+                            "times": [
+                                [
+                                    0,
+                                    0
+                                ]
+                            ],
+                            "interpolate": false
+                        },
+                        {
+                            "type": "ScheduleDay",
+                            "identifier": "OfficeMedium BLDG_EQUIP_SCH_2013_Sat",
+                            "values": [
+                                0.2307553806,
+                                0.381234796,
+                                0.476543495,
+                                0.3335804465,
+                                0.285926097,
+                                0.2307553806
+                            ],
+                            "times": [
+                                [
+                                    0,
+                                    0
+                                ],
+                                [
+                                    6,
+                                    0
+                                ],
+                                [
+                                    8,
+                                    0
+                                ],
+                                [
+                                    12,
+                                    0
+                                ],
+                                [
+                                    17,
+                                    0
+                                ],
+                                [
+                                    19,
+                                    0
+                                ]
+                            ],
+                            "interpolate": false
+                        },
+                        {
+                            "type": "ScheduleDay",
+                            "identifier": "OfficeMedium BLDG_EQUIP_SCH_2013_Wkdy",
+                            "values": [
+                                0.3076738408,
+                                0.381234796,
+                                0.857778291,
+                                0.762469592,
+                                0.857778291,
+                                0.476543495,
+                                0.381234796
+                            ],
+                            "times": [
+                                [
+                                    0,
+                                    0
+                                ],
+                                [
+                                    6,
+                                    0
+                                ],
+                                [
+                                    8,
+                                    0
+                                ],
+                                [
+                                    12,
+                                    0
+                                ],
+                                [
+                                    13,
+                                    0
+                                ],
+                                [
+                                    17,
+                                    0
+                                ],
+                                [
+                                    18,
+                                    0
+                                ]
+                            ],
+                            "interpolate": false
+                        }
+                    ],
+                    "default_day_schedule": "OfficeMedium BLDG_EQUIP_SCH_2013_Sun",
+                    "schedule_rules": [
+                        {
+                            "type": "ScheduleRuleAbridged",
+                            "schedule_day": "OfficeMedium BLDG_EQUIP_SCH_2013_Wkdy",
+                            "apply_sunday": false,
+                            "apply_monday": true,
+                            "apply_tuesday": true,
+                            "apply_wednesday": true,
+                            "apply_thursday": true,
+                            "apply_friday": true,
+                            "apply_saturday": false,
+                            "start_date": [
+                                1,
+                                1
+                            ],
+                            "end_date": [
+                                12,
+                                31
+                            ]
+                        },
+                        {
+                            "type": "ScheduleRuleAbridged",
+                            "schedule_day": "OfficeMedium BLDG_EQUIP_SCH_2013_Sat",
+                            "apply_sunday": false,
+                            "apply_monday": false,
+                            "apply_tuesday": false,
+                            "apply_wednesday": false,
+                            "apply_thursday": false,
+                            "apply_friday": false,
+                            "apply_saturday": true,
+                            "start_date": [
+                                1,
+                                1
+                            ],
+                            "end_date": [
+                                12,
+                                31
+                            ]
+                        }
+                    ],
+                    "holiday_schedule": "OfficeMedium BLDG_EQUIP_SCH_2013_Sat",
+                    "summer_designday_schedule": "OfficeMedium BLDG_EQUIP_SCH_2013_SmrDsn",
+                    "winter_designday_schedule": "OfficeMedium BLDG_EQUIP_SCH_2013_WntrDsn",
+                    "schedule_type_limit": "Fractional"
+                },
+                {
+                    "type": "ScheduleRulesetAbridged",
+                    "identifier": "Generic Office Infiltration",
+                    "day_schedules": [
+                        {
+                            "type": "ScheduleDay",
+                            "identifier": "OfficeMedium INFIL_SCH_PNNL_Default",
+                            "values": [
+                                1.0
+                            ],
+                            "times": [
+                                [
+                                    0,
+                                    0
+                                ]
+                            ],
+                            "interpolate": false
+                        },
+                        {
+                            "type": "ScheduleDay",
+                            "identifier": "OfficeMedium INFIL_SCH_PNNL_Wkdy_SmrDsn",
+                            "values": [
+                                1.0,
+                                0.25,
+                                1.0
+                            ],
+                            "times": [
+                                [
+                                    0,
+                                    0
+                                ],
+                                [
+                                    6,
+                                    0
+                                ],
+                                [
+                                    22,
+                                    0
+                                ]
+                            ],
+                            "interpolate": false
+                        },
+                        {
+                            "type": "ScheduleDay",
+                            "identifier": "OfficeMedium INFIL_SCH_PNNL_Sat_WntrDsn",
+                            "values": [
+                                1.0,
+                                0.25,
+                                1.0
+                            ],
+                            "times": [
+                                [
+                                    0,
+                                    0
+                                ],
+                                [
+                                    6,
+                                    0
+                                ],
+                                [
+                                    18,
+                                    0
+                                ]
+                            ],
+                            "interpolate": false
+                        },
+                        {
+                            "type": "ScheduleDay",
+                            "identifier": "OfficeMedium INFIL_SCH_PNNL_Wkdy",
+                            "values": [
+                                1.0,
+                                0.25,
+                                1.0
+                            ],
+                            "times": [
+                                [
+                                    0,
+                                    0
+                                ],
+                                [
+                                    6,
+                                    0
+                                ],
+                                [
+                                    22,
+                                    0
+                                ]
+                            ],
+                            "interpolate": false
+                        },
+                        {
+                            "type": "ScheduleDay",
+                            "identifier": "OfficeMedium INFIL_SCH_PNNL_Sat",
+                            "values": [
+                                1.0,
+                                0.25,
+                                1.0
+                            ],
+                            "times": [
+                                [
+                                    0,
+                                    0
+                                ],
+                                [
+                                    6,
+                                    0
+                                ],
+                                [
+                                    18,
+                                    0
+                                ]
+                            ],
+                            "interpolate": false
+                        }
+                    ],
+                    "default_day_schedule": "OfficeMedium INFIL_SCH_PNNL_Default",
+                    "schedule_rules": [
+                        {
+                            "type": "ScheduleRuleAbridged",
+                            "schedule_day": "OfficeMedium INFIL_SCH_PNNL_Wkdy",
+                            "apply_sunday": false,
+                            "apply_monday": true,
+                            "apply_tuesday": true,
+                            "apply_wednesday": true,
+                            "apply_thursday": true,
+                            "apply_friday": true,
+                            "apply_saturday": false,
+                            "start_date": [
+                                1,
+                                1
+                            ],
+                            "end_date": [
+                                12,
+                                31
+                            ]
+                        },
+                        {
+                            "type": "ScheduleRuleAbridged",
+                            "schedule_day": "OfficeMedium INFIL_SCH_PNNL_Sat",
+                            "apply_sunday": false,
+                            "apply_monday": false,
+                            "apply_tuesday": false,
+                            "apply_wednesday": false,
+                            "apply_thursday": false,
+                            "apply_friday": false,
+                            "apply_saturday": true,
+                            "start_date": [
+                                1,
+                                1
+                            ],
+                            "end_date": [
+                                12,
+                                31
+                            ]
+                        }
+                    ],
+                    "holiday_schedule": "OfficeMedium INFIL_SCH_PNNL_Default",
+                    "summer_designday_schedule": "OfficeMedium INFIL_SCH_PNNL_Wkdy_SmrDsn",
+                    "winter_designday_schedule": "OfficeMedium INFIL_SCH_PNNL_Sat_WntrDsn",
+                    "schedule_type_limit": "Fractional"
+                },
+                {
+                    "type": "ScheduleRulesetAbridged",
+                    "identifier": "Seated Adult Activity",
+                    "day_schedules": [
+                        {
+                            "type": "ScheduleDay",
+                            "identifier": "Seated Adult Activity_Day Schedule",
+                            "values": [
+                                120.0
+                            ],
+                            "times": [
+                                [
+                                    0,
+                                    0
+                                ]
+                            ],
+                            "interpolate": false
+                        }
+                    ],
+                    "default_day_schedule": "Seated Adult Activity_Day Schedule",
+                    "schedule_type_limit": "Activity Level"
+                },
+                {
+                    "type": "ScheduleRulesetAbridged",
+                    "identifier": "Generic Office Cooling",
+                    "day_schedules": [
+                        {
+                            "type": "ScheduleDay",
+                            "identifier": "OfficeMedium CLGSETP_SCH_YES_OPTIMUM_Default",
+                            "values": [
+                                26.7
+                            ],
+                            "times": [
+                                [
+                                    0,
+                                    0
+                                ]
+                            ],
+                            "interpolate": false
+                        },
+                        {
+                            "type": "ScheduleDay",
+                            "identifier": "OfficeMedium CLGSETP_SCH_YES_OPTIMUM_SmrDsn",
+                            "values": [
+                                26.7,
+                                25.7,
+                                25.0,
+                                24.0,
+                                26.7
+                            ],
+                            "times": [
+                                [
+                                    0,
+                                    0
+                                ],
+                                [
+                                    5,
+                                    0
+                                ],
+                                [
+                                    6,
+                                    0
+                                ],
+                                [
+                                    7,
+                                    0
+                                ],
+                                [
+                                    22,
+                                    0
+                                ]
+                            ],
+                            "interpolate": false
+                        },
+                        {
+                            "type": "ScheduleDay",
+                            "identifier": "OfficeMedium CLGSETP_SCH_YES_OPTIMUM_Default_WntrDsn",
+                            "values": [
+                                26.7
+                            ],
+                            "times": [
+                                [
+                                    0,
+                                    0
+                                ]
+                            ],
+                            "interpolate": false
+                        },
+                        {
+                            "type": "ScheduleDay",
+                            "identifier": "OfficeMedium CLGSETP_SCH_YES_OPTIMUM_Wkdy",
+                            "values": [
+                                26.7,
+                                25.6,
+                                25.0,
+                                24.0,
+                                26.7
+                            ],
+                            "times": [
+                                [
+                                    0,
+                                    0
+                                ],
+                                [
+                                    5,
+                                    0
+                                ],
+                                [
+                                    6,
+                                    0
+                                ],
+                                [
+                                    7,
+                                    0
+                                ],
+                                [
+                                    22,
+                                    0
+                                ]
+                            ],
+                            "interpolate": false
+                        },
+                        {
+                            "type": "ScheduleDay",
+                            "identifier": "OfficeMedium CLGSETP_SCH_YES_OPTIMUM_Sat",
+                            "values": [
+                                26.7,
+                                25.7,
+                                25.0,
+                                24.0,
+                                26.7
+                            ],
+                            "times": [
+                                [
+                                    0,
+                                    0
+                                ],
+                                [
+                                    5,
+                                    0
+                                ],
+                                [
+                                    6,
+                                    0
+                                ],
+                                [
+                                    7,
+                                    0
+                                ],
+                                [
+                                    17,
+                                    0
+                                ]
+                            ],
+                            "interpolate": false
+                        }
+                    ],
+                    "default_day_schedule": "OfficeMedium CLGSETP_SCH_YES_OPTIMUM_Default",
+                    "schedule_rules": [
+                        {
+                            "type": "ScheduleRuleAbridged",
+                            "schedule_day": "OfficeMedium CLGSETP_SCH_YES_OPTIMUM_Wkdy",
+                            "apply_sunday": false,
+                            "apply_monday": true,
+                            "apply_tuesday": true,
+                            "apply_wednesday": true,
+                            "apply_thursday": true,
+                            "apply_friday": true,
+                            "apply_saturday": false,
+                            "start_date": [
+                                1,
+                                1
+                            ],
+                            "end_date": [
+                                12,
+                                31
+                            ]
+                        },
+                        {
+                            "type": "ScheduleRuleAbridged",
+                            "schedule_day": "OfficeMedium CLGSETP_SCH_YES_OPTIMUM_Sat",
+                            "apply_sunday": false,
+                            "apply_monday": false,
+                            "apply_tuesday": false,
+                            "apply_wednesday": false,
+                            "apply_thursday": false,
+                            "apply_friday": false,
+                            "apply_saturday": true,
+                            "start_date": [
+                                1,
+                                1
+                            ],
+                            "end_date": [
+                                12,
+                                31
+                            ]
+                        }
+                    ],
+                    "holiday_schedule": "OfficeMedium CLGSETP_SCH_YES_OPTIMUM_Default",
+                    "summer_designday_schedule": "OfficeMedium CLGSETP_SCH_YES_OPTIMUM_SmrDsn",
+                    "winter_designday_schedule": "OfficeMedium CLGSETP_SCH_YES_OPTIMUM_Default_WntrDsn",
+                    "schedule_type_limit": "Temperature"
+                },
+                {
+                    "type": "ScheduleRulesetAbridged",
+                    "identifier": "Generic Office Heating",
+                    "day_schedules": [
+                        {
+                            "type": "ScheduleDay",
+                            "identifier": "OfficeMedium HTGSETP_SCH_YES_OPTIMUM_Default",
+                            "values": [
+                                15.6
+                            ],
+                            "times": [
+                                [
+                                    0,
+                                    0
+                                ]
+                            ],
+                            "interpolate": false
+                        },
+                        {
+                            "type": "ScheduleDay",
+                            "identifier": "OfficeMedium HTGSETP_SCH_YES_OPTIMUM_Default_SmrDsn",
+                            "values": [
+                                15.6
+                            ],
+                            "times": [
+                                [
+                                    0,
+                                    0
+                                ]
+                            ],
+                            "interpolate": false
+                        },
+                        {
+                            "type": "ScheduleDay",
+                            "identifier": "OfficeMedium HTGSETP_SCH_YES_OPTIMUM_WntrDsn",
+                            "values": [
+                                15.6,
+                                17.6,
+                                19.6,
+                                21.0,
+                                15.6
+                            ],
+                            "times": [
+                                [
+                                    0,
+                                    0
+                                ],
+                                [
+                                    5,
+                                    0
+                                ],
+                                [
+                                    6,
+                                    0
+                                ],
+                                [
+                                    7,
+                                    0
+                                ],
+                                [
+                                    22,
+                                    0
+                                ]
+                            ],
+                            "interpolate": false
+                        },
+                        {
+                            "type": "ScheduleDay",
+                            "identifier": "OfficeMedium HTGSETP_SCH_YES_OPTIMUM_Wkdy",
+                            "values": [
+                                15.6,
+                                17.8,
+                                20.0,
+                                21.0,
+                                15.6
+                            ],
+                            "times": [
+                                [
+                                    0,
+                                    0
+                                ],
+                                [
+                                    5,
+                                    0
+                                ],
+                                [
+                                    6,
+                                    0
+                                ],
+                                [
+                                    7,
+                                    0
+                                ],
+                                [
+                                    22,
+                                    0
+                                ]
+                            ],
+                            "interpolate": false
+                        },
+                        {
+                            "type": "ScheduleDay",
+                            "identifier": "OfficeMedium HTGSETP_SCH_YES_OPTIMUM_Sat",
+                            "values": [
+                                15.6,
+                                17.8,
+                                20.0,
+                                21.0,
+                                15.6
+                            ],
+                            "times": [
+                                [
+                                    0,
+                                    0
+                                ],
+                                [
+                                    5,
+                                    0
+                                ],
+                                [
+                                    6,
+                                    0
+                                ],
+                                [
+                                    7,
+                                    0
+                                ],
+                                [
+                                    17,
+                                    0
+                                ]
+                            ],
+                            "interpolate": false
+                        }
+                    ],
+                    "default_day_schedule": "OfficeMedium HTGSETP_SCH_YES_OPTIMUM_Default",
+                    "schedule_rules": [
+                        {
+                            "type": "ScheduleRuleAbridged",
+                            "schedule_day": "OfficeMedium HTGSETP_SCH_YES_OPTIMUM_Wkdy",
+                            "apply_sunday": false,
+                            "apply_monday": true,
+                            "apply_tuesday": true,
+                            "apply_wednesday": true,
+                            "apply_thursday": true,
+                            "apply_friday": true,
+                            "apply_saturday": false,
+                            "start_date": [
+                                1,
+                                1
+                            ],
+                            "end_date": [
+                                12,
+                                31
+                            ]
+                        },
+                        {
+                            "type": "ScheduleRuleAbridged",
+                            "schedule_day": "OfficeMedium HTGSETP_SCH_YES_OPTIMUM_Sat",
+                            "apply_sunday": false,
+                            "apply_monday": false,
+                            "apply_tuesday": false,
+                            "apply_wednesday": false,
+                            "apply_thursday": false,
+                            "apply_friday": false,
+                            "apply_saturday": true,
+                            "start_date": [
+                                1,
+                                1
+                            ],
+                            "end_date": [
+                                12,
+                                31
+                            ]
+                        }
+                    ],
+                    "holiday_schedule": "OfficeMedium HTGSETP_SCH_YES_OPTIMUM_Default",
+                    "summer_designday_schedule": "OfficeMedium HTGSETP_SCH_YES_OPTIMUM_Default_SmrDsn",
+                    "winter_designday_schedule": "OfficeMedium HTGSETP_SCH_YES_OPTIMUM_WntrDsn",
+                    "schedule_type_limit": "Temperature"
+                }
+            ],
+            "schedule_type_limits": [
+                {
+                    "type": "ScheduleTypeLimit",
+                    "identifier": "Temperature",
+                    "lower_limit": -273.15,
+                    "upper_limit": {
+                        "type": "NoLimit"
+                    },
+                    "numeric_type": "Continuous",
+                    "unit_type": "Temperature"
+                },
+                {
+                    "type": "ScheduleTypeLimit",
+                    "identifier": "Activity Level",
+                    "lower_limit": 0.0,
+                    "upper_limit": {
+                        "type": "NoLimit"
+                    },
+                    "numeric_type": "Continuous",
+                    "unit_type": "ActivityLevel"
+                },
+                {
+                    "type": "ScheduleTypeLimit",
+                    "identifier": "Fractional",
+                    "lower_limit": 0.0,
+                    "upper_limit": 1.0,
+                    "numeric_type": "Continuous",
+                    "unit_type": "Dimensionless"
+                }
+            ]
+        }
+    },
+    "rooms": [
+        {
+            "type": "Room",
+            "identifier": "First_Floor",
+            "display_name": "First_Floor",
+            "properties": {
+                "type": "RoomPropertiesAbridged",
+                "energy": {
+                    "type": "RoomEnergyPropertiesAbridged",
+                    "program_type": "Generic Office Program",
+                    "hvac": "FCU System with DOAS Enthalpy Wheel"
+                }
+            },
+            "faces": [
+                {
+                    "type": "Face",
+                    "identifier": "First_Floor_Bottom",
+                    "display_name": "First_Floor_Bottom",
+                    "properties": {
+                        "type": "FacePropertiesAbridged",
+                        "energy": {
+                            "type": "FaceEnergyPropertiesAbridged"
+                        }
+                    },
+                    "geometry": {
+                        "type": "Face3D",
+                        "boundary": [
+                            [
+                                0.0,
+                                0.0,
+                                0.0
+                            ],
+                            [
+                                0.0,
+                                10.0,
+                                0.0
+                            ],
+                            [
+                                10.0,
+                                10.0,
+                                0.0
+                            ],
+                            [
+                                10.0,
+                                0.0,
+                                0.0
+                            ]
+                        ]
+                    },
+                    "face_type": "Floor",
+                    "boundary_condition": {
+                        "type": "Ground"
+                    }
+                },
+                {
+                    "type": "Face",
+                    "identifier": "First_Floor_Front",
+                    "display_name": "First_Floor_Front",
+                    "properties": {
+                        "type": "FacePropertiesAbridged",
+                        "energy": {
+                            "type": "FaceEnergyPropertiesAbridged"
+                        }
+                    },
+                    "geometry": {
+                        "type": "Face3D",
+                        "boundary": [
+                            [
+                                10.0,
+                                10.0,
+                                3.0
+                            ],
+                            [
+                                10.0,
+                                10.0,
+                                0.0
+                            ],
+                            [
+                                0.0,
+                                10.0,
+                                0.0
+                            ],
+                            [
+                                0.0,
+                                10.0,
+                                3.0
+                            ]
+                        ]
+                    },
+                    "face_type": "Wall",
+                    "boundary_condition": {
+                        "type": "Outdoors",
+                        "sun_exposure": true,
+                        "wind_exposure": true,
+                        "view_factor": {
+                            "type": "Autocalculate"
+                        }
+                    },
+                    "apertures": [
+                        {
+                            "type": "Aperture",
+                            "identifier": "First_Floor_Front_Glz0",
+                            "display_name": "First_Floor_Front_Glz0",
+                            "properties": {
+                                "type": "AperturePropertiesAbridged",
+                                "energy": {
+                                    "type": "ApertureEnergyPropertiesAbridged"
+                                }
+                            },
+                            "geometry": {
+                                "type": "Face3D",
+                                "boundary": [
+                                    [
+                                        7.23606797749979,
+                                        10.0,
+                                        2.170820393249937
+                                    ],
+                                    [
+                                        7.23606797749979,
+                                        10.0,
+                                        0.8291796067500631
+                                    ],
+                                    [
+                                        2.76393202250021,
+                                        10.0,
+                                        0.8291796067500631
+                                    ],
+                                    [
+                                        2.76393202250021,
+                                        10.0,
+                                        2.170820393249937
+                                    ]
+                                ]
+                            },
+                            "is_operable": false,
+                            "boundary_condition": {
+                                "type": "Outdoors",
+                                "sun_exposure": true,
+                                "wind_exposure": true,
+                                "view_factor": {
+                                    "type": "Autocalculate"
+                                }
+                            }
+                        }
+                    ]
+                },
+                {
+                    "type": "Face",
+                    "identifier": "First_Floor_Right",
+                    "display_name": "First_Floor_Right",
+                    "properties": {
+                        "type": "FacePropertiesAbridged",
+                        "energy": {
+                            "type": "FaceEnergyPropertiesAbridged"
+                        }
+                    },
+                    "geometry": {
+                        "type": "Face3D",
+                        "boundary": [
+                            [
+                                10.0,
+                                0.0,
+                                3.0
+                            ],
+                            [
+                                10.0,
+                                0.0,
+                                0.0
+                            ],
+                            [
+                                10.0,
+                                10.0,
+                                0.0
+                            ],
+                            [
+                                10.0,
+                                10.0,
+                                3.0
+                            ]
+                        ]
+                    },
+                    "face_type": "Wall",
+                    "boundary_condition": {
+                        "type": "Outdoors",
+                        "sun_exposure": true,
+                        "wind_exposure": true,
+                        "view_factor": {
+                            "type": "Autocalculate"
+                        }
+                    },
+                    "apertures": [
+                        {
+                            "type": "Aperture",
+                            "identifier": "First_Floor_Right_Glz0",
+                            "display_name": "First_Floor_Right_Glz0",
+                            "properties": {
+                                "type": "AperturePropertiesAbridged",
+                                "energy": {
+                                    "type": "ApertureEnergyPropertiesAbridged"
+                                }
+                            },
+                            "geometry": {
+                                "type": "Face3D",
+                                "boundary": [
+                                    [
+                                        10.0,
+                                        2.76393202250021,
+                                        2.170820393249937
+                                    ],
+                                    [
+                                        10.0,
+                                        2.76393202250021,
+                                        0.8291796067500631
+                                    ],
+                                    [
+                                        10.0,
+                                        7.23606797749979,
+                                        0.8291796067500631
+                                    ],
+                                    [
+                                        10.0,
+                                        7.23606797749979,
+                                        2.170820393249937
+                                    ]
+                                ]
+                            },
+                            "is_operable": false,
+                            "boundary_condition": {
+                                "type": "Outdoors",
+                                "sun_exposure": true,
+                                "wind_exposure": true,
+                                "view_factor": {
+                                    "type": "Autocalculate"
+                                }
+                            }
+                        }
+                    ]
+                },
+                {
+                    "type": "Face",
+                    "identifier": "First_Floor_Back",
+                    "display_name": "First_Floor_Back",
+                    "properties": {
+                        "type": "FacePropertiesAbridged",
+                        "energy": {
+                            "type": "FaceEnergyPropertiesAbridged"
+                        }
+                    },
+                    "geometry": {
+                        "type": "Face3D",
+                        "boundary": [
+                            [
+                                0.0,
+                                0.0,
+                                3.0
+                            ],
+                            [
+                                0.0,
+                                0.0,
+                                0.0
+                            ],
+                            [
+                                10.0,
+                                0.0,
+                                0.0
+                            ],
+                            [
+                                10.0,
+                                0.0,
+                                3.0
+                            ]
+                        ]
+                    },
+                    "face_type": "Wall",
+                    "boundary_condition": {
+                        "type": "Outdoors",
+                        "sun_exposure": true,
+                        "wind_exposure": true,
+                        "view_factor": {
+                            "type": "Autocalculate"
+                        }
+                    },
+                    "apertures": [
+                        {
+                            "type": "Aperture",
+                            "identifier": "First_Floor_Back_Glz0",
+                            "display_name": "First_Floor_Back_Glz0",
+                            "properties": {
+                                "type": "AperturePropertiesAbridged",
+                                "energy": {
+                                    "type": "ApertureEnergyPropertiesAbridged"
+                                }
+                            },
+                            "geometry": {
+                                "type": "Face3D",
+                                "boundary": [
+                                    [
+                                        2.76393202250021,
+                                        0.0,
+                                        2.170820393249937
+                                    ],
+                                    [
+                                        2.76393202250021,
+                                        0.0,
+                                        0.8291796067500631
+                                    ],
+                                    [
+                                        7.23606797749979,
+                                        0.0,
+                                        0.8291796067500631
+                                    ],
+                                    [
+                                        7.23606797749979,
+                                        0.0,
+                                        2.170820393249937
+                                    ]
+                                ]
+                            },
+                            "is_operable": false,
+                            "boundary_condition": {
+                                "type": "Outdoors",
+                                "sun_exposure": true,
+                                "wind_exposure": true,
+                                "view_factor": {
+                                    "type": "Autocalculate"
+                                }
+                            }
+                        }
+                    ]
+                },
+                {
+                    "type": "Face",
+                    "identifier": "First_Floor_Left",
+                    "display_name": "First_Floor_Left",
+                    "properties": {
+                        "type": "FacePropertiesAbridged",
+                        "energy": {
+                            "type": "FaceEnergyPropertiesAbridged"
+                        }
+                    },
+                    "geometry": {
+                        "type": "Face3D",
+                        "boundary": [
+                            [
+                                0.0,
+                                10.0,
+                                3.0
+                            ],
+                            [
+                                0.0,
+                                10.0,
+                                0.0
+                            ],
+                            [
+                                0.0,
+                                0.0,
+                                0.0
+                            ],
+                            [
+                                0.0,
+                                0.0,
+                                3.0
+                            ]
+                        ]
+                    },
+                    "face_type": "Wall",
+                    "boundary_condition": {
+                        "type": "Outdoors",
+                        "sun_exposure": true,
+                        "wind_exposure": true,
+                        "view_factor": {
+                            "type": "Autocalculate"
+                        }
+                    },
+                    "apertures": [
+                        {
+                            "type": "Aperture",
+                            "identifier": "First_Floor_Left_Glz0",
+                            "display_name": "First_Floor_Left_Glz0",
+                            "properties": {
+                                "type": "AperturePropertiesAbridged",
+                                "energy": {
+                                    "type": "ApertureEnergyPropertiesAbridged"
+                                }
+                            },
+                            "geometry": {
+                                "type": "Face3D",
+                                "boundary": [
+                                    [
+                                        0.0,
+                                        7.23606797749979,
+                                        2.170820393249937
+                                    ],
+                                    [
+                                        0.0,
+                                        7.23606797749979,
+                                        0.8291796067500631
+                                    ],
+                                    [
+                                        0.0,
+                                        2.76393202250021,
+                                        0.8291796067500631
+                                    ],
+                                    [
+                                        0.0,
+                                        2.76393202250021,
+                                        2.170820393249937
+                                    ]
+                                ]
+                            },
+                            "is_operable": false,
+                            "boundary_condition": {
+                                "type": "Outdoors",
+                                "sun_exposure": true,
+                                "wind_exposure": true,
+                                "view_factor": {
+                                    "type": "Autocalculate"
+                                }
+                            }
+                        }
+                    ]
+                },
+                {
+                    "type": "Face",
+                    "identifier": "First_Floor_Top",
+                    "display_name": "First_Floor_Top",
+                    "properties": {
+                        "type": "FacePropertiesAbridged",
+                        "energy": {
+                            "type": "FaceEnergyPropertiesAbridged"
+                        }
+                    },
+                    "geometry": {
+                        "type": "Face3D",
+                        "boundary": [
+                            [
+                                10.0,
+                                0.0,
+                                3.0
+                            ],
+                            [
+                                10.0,
+                                10.0,
+                                3.0
+                            ],
+                            [
+                                0.0,
+                                10.0,
+                                3.0
+                            ],
+                            [
+                                0.0,
+                                0.0,
+                                3.0
+                            ]
+                        ]
+                    },
+                    "face_type": "RoofCeiling",
+                    "boundary_condition": {
+                        "type": "Surface",
+                        "boundary_condition_objects": [
+                            "Second_Floor_Bottom",
+                            "Second_Floor"
+                        ]
+                    }
+                }
+            ]
+        },
+        {
+            "type": "Room",
+            "identifier": "Second_Floor",
+            "display_name": "Second_Floor",
+            "properties": {
+                "type": "RoomPropertiesAbridged",
+                "energy": {
+                    "type": "RoomEnergyPropertiesAbridged",
+                    "program_type": "Generic Office Program",
+                    "hvac": "FCU System with DOAS Enthalpy Wheel"
+                }
+            },
+            "faces": [
+                {
+                    "type": "Face",
+                    "identifier": "Second_Floor_Bottom",
+                    "display_name": "Second_Floor_Bottom",
+                    "properties": {
+                        "type": "FacePropertiesAbridged",
+                        "energy": {
+                            "type": "FaceEnergyPropertiesAbridged"
+                        }
+                    },
+                    "geometry": {
+                        "type": "Face3D",
+                        "boundary": [
+                            [
+                                0.0,
+                                0.0,
+                                3.0
+                            ],
+                            [
+                                0.0,
+                                10.0,
+                                3.0
+                            ],
+                            [
+                                10.0,
+                                10.0,
+                                3.0
+                            ],
+                            [
+                                10.0,
+                                0.0,
+                                3.0
+                            ]
+                        ]
+                    },
+                    "face_type": "Floor",
+                    "boundary_condition": {
+                        "type": "Surface",
+                        "boundary_condition_objects": [
+                            "First_Floor_Top",
+                            "First_Floor"
+                        ]
+                    }
+                },
+                {
+                    "type": "Face",
+                    "identifier": "Second_Floor_Front",
+                    "display_name": "Second_Floor_Front",
+                    "properties": {
+                        "type": "FacePropertiesAbridged",
+                        "energy": {
+                            "type": "FaceEnergyPropertiesAbridged"
+                        }
+                    },
+                    "geometry": {
+                        "type": "Face3D",
+                        "boundary": [
+                            [
+                                10.0,
+                                10.0,
+                                6.0
+                            ],
+                            [
+                                10.0,
+                                10.0,
+                                3.0
+                            ],
+                            [
+                                0.0,
+                                10.0,
+                                3.0
+                            ],
+                            [
+                                0.0,
+                                10.0,
+                                6.0
+                            ]
+                        ]
+                    },
+                    "face_type": "Wall",
+                    "boundary_condition": {
+                        "type": "Outdoors",
+                        "sun_exposure": true,
+                        "wind_exposure": true,
+                        "view_factor": {
+                            "type": "Autocalculate"
+                        }
+                    },
+                    "apertures": [
+                        {
+                            "type": "Aperture",
+                            "identifier": "Second_Floor_Front_Glz0",
+                            "display_name": "Second_Floor_Front_Glz0",
+                            "properties": {
+                                "type": "AperturePropertiesAbridged",
+                                "energy": {
+                                    "type": "ApertureEnergyPropertiesAbridged"
+                                }
+                            },
+                            "geometry": {
+                                "type": "Face3D",
+                                "boundary": [
+                                    [
+                                        7.23606797749979,
+                                        10.0,
+                                        5.170820393249937
+                                    ],
+                                    [
+                                        7.23606797749979,
+                                        10.0,
+                                        3.829179606750063
+                                    ],
+                                    [
+                                        2.76393202250021,
+                                        10.0,
+                                        3.829179606750063
+                                    ],
+                                    [
+                                        2.76393202250021,
+                                        10.0,
+                                        5.170820393249937
+                                    ]
+                                ]
+                            },
+                            "is_operable": false,
+                            "boundary_condition": {
+                                "type": "Outdoors",
+                                "sun_exposure": true,
+                                "wind_exposure": true,
+                                "view_factor": {
+                                    "type": "Autocalculate"
+                                }
+                            }
+                        }
+                    ]
+                },
+                {
+                    "type": "Face",
+                    "identifier": "Second_Floor_Right",
+                    "display_name": "Second_Floor_Right",
+                    "properties": {
+                        "type": "FacePropertiesAbridged",
+                        "energy": {
+                            "type": "FaceEnergyPropertiesAbridged"
+                        }
+                    },
+                    "geometry": {
+                        "type": "Face3D",
+                        "boundary": [
+                            [
+                                10.0,
+                                0.0,
+                                6.0
+                            ],
+                            [
+                                10.0,
+                                0.0,
+                                3.0
+                            ],
+                            [
+                                10.0,
+                                10.0,
+                                3.0
+                            ],
+                            [
+                                10.0,
+                                10.0,
+                                6.0
+                            ]
+                        ]
+                    },
+                    "face_type": "Wall",
+                    "boundary_condition": {
+                        "type": "Outdoors",
+                        "sun_exposure": true,
+                        "wind_exposure": true,
+                        "view_factor": {
+                            "type": "Autocalculate"
+                        }
+                    },
+                    "apertures": [
+                        {
+                            "type": "Aperture",
+                            "identifier": "Second_Floor_Right_Glz0",
+                            "display_name": "Second_Floor_Right_Glz0",
+                            "properties": {
+                                "type": "AperturePropertiesAbridged",
+                                "energy": {
+                                    "type": "ApertureEnergyPropertiesAbridged"
+                                }
+                            },
+                            "geometry": {
+                                "type": "Face3D",
+                                "boundary": [
+                                    [
+                                        10.0,
+                                        2.76393202250021,
+                                        5.170820393249937
+                                    ],
+                                    [
+                                        10.0,
+                                        2.76393202250021,
+                                        3.829179606750063
+                                    ],
+                                    [
+                                        10.0,
+                                        7.23606797749979,
+                                        3.829179606750063
+                                    ],
+                                    [
+                                        10.0,
+                                        7.23606797749979,
+                                        5.170820393249937
+                                    ]
+                                ]
+                            },
+                            "is_operable": false,
+                            "boundary_condition": {
+                                "type": "Outdoors",
+                                "sun_exposure": true,
+                                "wind_exposure": true,
+                                "view_factor": {
+                                    "type": "Autocalculate"
+                                }
+                            }
+                        }
+                    ]
+                },
+                {
+                    "type": "Face",
+                    "identifier": "Second_Floor_Back",
+                    "display_name": "Second_Floor_Back",
+                    "properties": {
+                        "type": "FacePropertiesAbridged",
+                        "energy": {
+                            "type": "FaceEnergyPropertiesAbridged"
+                        }
+                    },
+                    "geometry": {
+                        "type": "Face3D",
+                        "boundary": [
+                            [
+                                0.0,
+                                0.0,
+                                6.0
+                            ],
+                            [
+                                0.0,
+                                0.0,
+                                3.0
+                            ],
+                            [
+                                10.0,
+                                0.0,
+                                3.0
+                            ],
+                            [
+                                10.0,
+                                0.0,
+                                6.0
+                            ]
+                        ]
+                    },
+                    "face_type": "Wall",
+                    "boundary_condition": {
+                        "type": "Outdoors",
+                        "sun_exposure": true,
+                        "wind_exposure": true,
+                        "view_factor": {
+                            "type": "Autocalculate"
+                        }
+                    },
+                    "apertures": [
+                        {
+                            "type": "Aperture",
+                            "identifier": "Second_Floor_Back_Glz0",
+                            "display_name": "Second_Floor_Back_Glz0",
+                            "properties": {
+                                "type": "AperturePropertiesAbridged",
+                                "energy": {
+                                    "type": "ApertureEnergyPropertiesAbridged"
+                                }
+                            },
+                            "geometry": {
+                                "type": "Face3D",
+                                "boundary": [
+                                    [
+                                        2.76393202250021,
+                                        0.0,
+                                        5.170820393249937
+                                    ],
+                                    [
+                                        2.76393202250021,
+                                        0.0,
+                                        3.829179606750063
+                                    ],
+                                    [
+                                        7.23606797749979,
+                                        0.0,
+                                        3.829179606750063
+                                    ],
+                                    [
+                                        7.23606797749979,
+                                        0.0,
+                                        5.170820393249937
+                                    ]
+                                ]
+                            },
+                            "is_operable": false,
+                            "boundary_condition": {
+                                "type": "Outdoors",
+                                "sun_exposure": true,
+                                "wind_exposure": true,
+                                "view_factor": {
+                                    "type": "Autocalculate"
+                                }
+                            }
+                        }
+                    ]
+                },
+                {
+                    "type": "Face",
+                    "identifier": "Second_Floor_Left",
+                    "display_name": "Second_Floor_Left",
+                    "properties": {
+                        "type": "FacePropertiesAbridged",
+                        "energy": {
+                            "type": "FaceEnergyPropertiesAbridged"
+                        }
+                    },
+                    "geometry": {
+                        "type": "Face3D",
+                        "boundary": [
+                            [
+                                0.0,
+                                10.0,
+                                6.0
+                            ],
+                            [
+                                0.0,
+                                10.0,
+                                3.0
+                            ],
+                            [
+                                0.0,
+                                0.0,
+                                3.0
+                            ],
+                            [
+                                0.0,
+                                0.0,
+                                6.0
+                            ]
+                        ]
+                    },
+                    "face_type": "Wall",
+                    "boundary_condition": {
+                        "type": "Outdoors",
+                        "sun_exposure": true,
+                        "wind_exposure": true,
+                        "view_factor": {
+                            "type": "Autocalculate"
+                        }
+                    },
+                    "apertures": [
+                        {
+                            "type": "Aperture",
+                            "identifier": "Second_Floor_Left_Glz0",
+                            "display_name": "Second_Floor_Left_Glz0",
+                            "properties": {
+                                "type": "AperturePropertiesAbridged",
+                                "energy": {
+                                    "type": "ApertureEnergyPropertiesAbridged"
+                                }
+                            },
+                            "geometry": {
+                                "type": "Face3D",
+                                "boundary": [
+                                    [
+                                        0.0,
+                                        7.23606797749979,
+                                        5.170820393249937
+                                    ],
+                                    [
+                                        0.0,
+                                        7.23606797749979,
+                                        3.829179606750063
+                                    ],
+                                    [
+                                        0.0,
+                                        2.76393202250021,
+                                        3.829179606750063
+                                    ],
+                                    [
+                                        0.0,
+                                        2.76393202250021,
+                                        5.170820393249937
+                                    ]
+                                ]
+                            },
+                            "is_operable": false,
+                            "boundary_condition": {
+                                "type": "Outdoors",
+                                "sun_exposure": true,
+                                "wind_exposure": true,
+                                "view_factor": {
+                                    "type": "Autocalculate"
+                                }
+                            }
+                        }
+                    ]
+                },
+                {
+                    "type": "Face",
+                    "identifier": "Second_Floor_Top",
+                    "display_name": "Second_Floor_Top",
+                    "properties": {
+                        "type": "FacePropertiesAbridged",
+                        "energy": {
+                            "type": "FaceEnergyPropertiesAbridged"
+                        }
+                    },
+                    "geometry": {
+                        "type": "Face3D",
+                        "boundary": [
+                            [
+                                10.0,
+                                0.0,
+                                6.0
+                            ],
+                            [
+                                10.0,
+                                10.0,
+                                6.0
+                            ],
+                            [
+                                0.0,
+                                10.0,
+                                6.0
+                            ],
+                            [
+                                0.0,
+                                0.0,
+                                6.0
+                            ]
+                        ]
+                    },
+                    "face_type": "RoofCeiling",
+                    "boundary_condition": {
+                        "type": "Outdoors",
+                        "sun_exposure": true,
+                        "wind_exposure": true,
+                        "view_factor": {
+                            "type": "Autocalculate"
+                        }
+                    }
+                }
+            ]
+        }
+    ],
+    "version": "1.35.1"
+}

--- a/samples/model/model_energy_window_ac.json
+++ b/samples/model/model_energy_window_ac.json
@@ -1,0 +1,2188 @@
+{
+    "type": "Model",
+    "identifier": "Model_Energy_Window_AC",
+    "display_name": "Model_Energy_Window_AC",
+    "units": "Meters",
+    "properties": {
+        "type": "ModelProperties",
+        "energy": {
+            "type": "ModelEnergyProperties",
+            "construction_sets": [],
+            "constructions": [],
+            "materials": [],
+            "hvacs": [
+                {
+                    "type": "WindowAC",
+                    "identifier": "FCU System with DOAS Heat Recovery",
+                    "vintage": "90.1-2013",
+                    "equipment_type": "Window AC with baseboard gas boiler"
+                }
+            ],
+            "program_types": [
+                {
+                    "type": "ProgramTypeAbridged",
+                    "identifier": "Generic Office Program",
+                    "people": {
+                        "type": "PeopleAbridged",
+                        "identifier": "Generic Office People",
+                        "people_per_area": 0.0565,
+                        "radiant_fraction": 0.3,
+                        "latent_fraction": {
+                            "type": "Autocalculate"
+                        },
+                        "occupancy_schedule": "Generic Office Occupancy",
+                        "activity_schedule": "Seated Adult Activity"
+                    },
+                    "lighting": {
+                        "type": "LightingAbridged",
+                        "identifier": "Generic Office Lighting",
+                        "watts_per_area": 10.55,
+                        "return_air_fraction": 0.0,
+                        "radiant_fraction": 0.7,
+                        "visible_fraction": 0.2,
+                        "schedule": "Generic Office Lighting"
+                    },
+                    "electric_equipment": {
+                        "type": "ElectricEquipmentAbridged",
+                        "identifier": "Generic Office Equipment",
+                        "watts_per_area": 10.33,
+                        "radiant_fraction": 0.5,
+                        "latent_fraction": 0.0,
+                        "lost_fraction": 0.0,
+                        "schedule": "Generic Office Equipment"
+                    },
+                    "infiltration": {
+                        "type": "InfiltrationAbridged",
+                        "identifier": "Generic Office Infiltration",
+                        "flow_per_exterior_area": 0.0002266,
+                        "schedule": "Generic Office Infiltration"
+                    },
+                    "ventilation": {
+                        "type": "VentilationAbridged",
+                        "identifier": "Generic Office Ventilation",
+                        "flow_per_person": 0.00236,
+                        "flow_per_area": 0.000305
+                    },
+                    "setpoint": {
+                        "type": "SetpointAbridged",
+                        "identifier": "Generic Office Setpoints",
+                        "heating_schedule": "Generic Office Heating",
+                        "cooling_schedule": "Generic Office Cooling"
+                    }
+                }
+            ],
+            "schedules": [
+                {
+                    "type": "ScheduleRulesetAbridged",
+                    "identifier": "Generic Office Occupancy",
+                    "day_schedules": [
+                        {
+                            "type": "ScheduleDay",
+                            "identifier": "OfficeMedium BLDG_OCC_SCH_Default",
+                            "values": [
+                                0.0,
+                                0.05,
+                                0.0
+                            ],
+                            "times": [
+                                [
+                                    0,
+                                    0
+                                ],
+                                [
+                                    6,
+                                    0
+                                ],
+                                [
+                                    18,
+                                    0
+                                ]
+                            ],
+                            "interpolate": false
+                        },
+                        {
+                            "type": "ScheduleDay",
+                            "identifier": "OfficeMedium BLDG_OCC_SCH_SmrDsn",
+                            "values": [
+                                0.0,
+                                1.0,
+                                0.05
+                            ],
+                            "times": [
+                                [
+                                    0,
+                                    0
+                                ],
+                                [
+                                    6,
+                                    0
+                                ],
+                                [
+                                    22,
+                                    0
+                                ]
+                            ],
+                            "interpolate": false
+                        },
+                        {
+                            "type": "ScheduleDay",
+                            "identifier": "OfficeMedium BLDG_OCC_SCH_WntrDsn",
+                            "values": [
+                                0.0
+                            ],
+                            "times": [
+                                [
+                                    0,
+                                    0
+                                ]
+                            ],
+                            "interpolate": false
+                        },
+                        {
+                            "type": "ScheduleDay",
+                            "identifier": "OfficeMedium BLDG_OCC_SCH_Wkdy",
+                            "values": [
+                                0.0,
+                                0.1,
+                                0.2,
+                                0.95,
+                                0.5,
+                                0.95,
+                                0.3,
+                                0.1,
+                                0.05
+                            ],
+                            "times": [
+                                [
+                                    0,
+                                    0
+                                ],
+                                [
+                                    6,
+                                    0
+                                ],
+                                [
+                                    7,
+                                    0
+                                ],
+                                [
+                                    8,
+                                    0
+                                ],
+                                [
+                                    12,
+                                    0
+                                ],
+                                [
+                                    13,
+                                    0
+                                ],
+                                [
+                                    17,
+                                    0
+                                ],
+                                [
+                                    18,
+                                    0
+                                ],
+                                [
+                                    22,
+                                    0
+                                ]
+                            ],
+                            "interpolate": false
+                        },
+                        {
+                            "type": "ScheduleDay",
+                            "identifier": "OfficeMedium BLDG_OCC_SCH_Sat",
+                            "values": [
+                                0.0,
+                                0.1,
+                                0.3,
+                                0.1,
+                                0.05,
+                                0.0
+                            ],
+                            "times": [
+                                [
+                                    0,
+                                    0
+                                ],
+                                [
+                                    6,
+                                    0
+                                ],
+                                [
+                                    8,
+                                    0
+                                ],
+                                [
+                                    12,
+                                    0
+                                ],
+                                [
+                                    17,
+                                    0
+                                ],
+                                [
+                                    19,
+                                    0
+                                ]
+                            ],
+                            "interpolate": false
+                        }
+                    ],
+                    "default_day_schedule": "OfficeMedium BLDG_OCC_SCH_Default",
+                    "schedule_rules": [
+                        {
+                            "type": "ScheduleRuleAbridged",
+                            "schedule_day": "OfficeMedium BLDG_OCC_SCH_Wkdy",
+                            "apply_sunday": false,
+                            "apply_monday": true,
+                            "apply_tuesday": true,
+                            "apply_wednesday": true,
+                            "apply_thursday": true,
+                            "apply_friday": true,
+                            "apply_saturday": false,
+                            "start_date": [
+                                1,
+                                1
+                            ],
+                            "end_date": [
+                                12,
+                                31
+                            ]
+                        },
+                        {
+                            "type": "ScheduleRuleAbridged",
+                            "schedule_day": "OfficeMedium BLDG_OCC_SCH_Sat",
+                            "apply_sunday": false,
+                            "apply_monday": false,
+                            "apply_tuesday": false,
+                            "apply_wednesday": false,
+                            "apply_thursday": false,
+                            "apply_friday": false,
+                            "apply_saturday": true,
+                            "start_date": [
+                                1,
+                                1
+                            ],
+                            "end_date": [
+                                12,
+                                31
+                            ]
+                        }
+                    ],
+                    "holiday_schedule": "OfficeMedium BLDG_OCC_SCH_Default",
+                    "summer_designday_schedule": "OfficeMedium BLDG_OCC_SCH_SmrDsn",
+                    "winter_designday_schedule": "OfficeMedium BLDG_OCC_SCH_WntrDsn",
+                    "schedule_type_limit": "Fractional"
+                },
+                {
+                    "type": "ScheduleRulesetAbridged",
+                    "identifier": "Generic Office Infiltration",
+                    "day_schedules": [
+                        {
+                            "type": "ScheduleDay",
+                            "identifier": "OfficeMedium INFIL_SCH_PNNL_Default",
+                            "values": [
+                                1.0
+                            ],
+                            "times": [
+                                [
+                                    0,
+                                    0
+                                ]
+                            ],
+                            "interpolate": false
+                        },
+                        {
+                            "type": "ScheduleDay",
+                            "identifier": "OfficeMedium INFIL_SCH_PNNL_Wkdy_SmrDsn",
+                            "values": [
+                                1.0,
+                                0.25,
+                                1.0
+                            ],
+                            "times": [
+                                [
+                                    0,
+                                    0
+                                ],
+                                [
+                                    6,
+                                    0
+                                ],
+                                [
+                                    22,
+                                    0
+                                ]
+                            ],
+                            "interpolate": false
+                        },
+                        {
+                            "type": "ScheduleDay",
+                            "identifier": "OfficeMedium INFIL_SCH_PNNL_Sat_WntrDsn",
+                            "values": [
+                                1.0,
+                                0.25,
+                                1.0
+                            ],
+                            "times": [
+                                [
+                                    0,
+                                    0
+                                ],
+                                [
+                                    6,
+                                    0
+                                ],
+                                [
+                                    18,
+                                    0
+                                ]
+                            ],
+                            "interpolate": false
+                        },
+                        {
+                            "type": "ScheduleDay",
+                            "identifier": "OfficeMedium INFIL_SCH_PNNL_Wkdy",
+                            "values": [
+                                1.0,
+                                0.25,
+                                1.0
+                            ],
+                            "times": [
+                                [
+                                    0,
+                                    0
+                                ],
+                                [
+                                    6,
+                                    0
+                                ],
+                                [
+                                    22,
+                                    0
+                                ]
+                            ],
+                            "interpolate": false
+                        },
+                        {
+                            "type": "ScheduleDay",
+                            "identifier": "OfficeMedium INFIL_SCH_PNNL_Sat",
+                            "values": [
+                                1.0,
+                                0.25,
+                                1.0
+                            ],
+                            "times": [
+                                [
+                                    0,
+                                    0
+                                ],
+                                [
+                                    6,
+                                    0
+                                ],
+                                [
+                                    18,
+                                    0
+                                ]
+                            ],
+                            "interpolate": false
+                        }
+                    ],
+                    "default_day_schedule": "OfficeMedium INFIL_SCH_PNNL_Default",
+                    "schedule_rules": [
+                        {
+                            "type": "ScheduleRuleAbridged",
+                            "schedule_day": "OfficeMedium INFIL_SCH_PNNL_Wkdy",
+                            "apply_sunday": false,
+                            "apply_monday": true,
+                            "apply_tuesday": true,
+                            "apply_wednesday": true,
+                            "apply_thursday": true,
+                            "apply_friday": true,
+                            "apply_saturday": false,
+                            "start_date": [
+                                1,
+                                1
+                            ],
+                            "end_date": [
+                                12,
+                                31
+                            ]
+                        },
+                        {
+                            "type": "ScheduleRuleAbridged",
+                            "schedule_day": "OfficeMedium INFIL_SCH_PNNL_Sat",
+                            "apply_sunday": false,
+                            "apply_monday": false,
+                            "apply_tuesday": false,
+                            "apply_wednesday": false,
+                            "apply_thursday": false,
+                            "apply_friday": false,
+                            "apply_saturday": true,
+                            "start_date": [
+                                1,
+                                1
+                            ],
+                            "end_date": [
+                                12,
+                                31
+                            ]
+                        }
+                    ],
+                    "holiday_schedule": "OfficeMedium INFIL_SCH_PNNL_Default",
+                    "summer_designday_schedule": "OfficeMedium INFIL_SCH_PNNL_Wkdy_SmrDsn",
+                    "winter_designday_schedule": "OfficeMedium INFIL_SCH_PNNL_Sat_WntrDsn",
+                    "schedule_type_limit": "Fractional"
+                },
+                {
+                    "type": "ScheduleRulesetAbridged",
+                    "identifier": "Generic Office Equipment",
+                    "day_schedules": [
+                        {
+                            "type": "ScheduleDay",
+                            "identifier": "OfficeMedium BLDG_EQUIP_SCH_2013_Sun",
+                            "values": [
+                                0.2307553806,
+                                0.288107175,
+                                0.2307553806
+                            ],
+                            "times": [
+                                [
+                                    0,
+                                    0
+                                ],
+                                [
+                                    6,
+                                    0
+                                ],
+                                [
+                                    18,
+                                    0
+                                ]
+                            ],
+                            "interpolate": false
+                        },
+                        {
+                            "type": "ScheduleDay",
+                            "identifier": "OfficeMedium BLDG_EQUIP_SCH_2013_SmrDsn",
+                            "values": [
+                                1.0
+                            ],
+                            "times": [
+                                [
+                                    0,
+                                    0
+                                ]
+                            ],
+                            "interpolate": false
+                        },
+                        {
+                            "type": "ScheduleDay",
+                            "identifier": "OfficeMedium BLDG_EQUIP_SCH_2013_WntrDsn",
+                            "values": [
+                                0.0
+                            ],
+                            "times": [
+                                [
+                                    0,
+                                    0
+                                ]
+                            ],
+                            "interpolate": false
+                        },
+                        {
+                            "type": "ScheduleDay",
+                            "identifier": "OfficeMedium BLDG_EQUIP_SCH_2013_Sat",
+                            "values": [
+                                0.2307553806,
+                                0.381234796,
+                                0.476543495,
+                                0.3335804465,
+                                0.285926097,
+                                0.2307553806
+                            ],
+                            "times": [
+                                [
+                                    0,
+                                    0
+                                ],
+                                [
+                                    6,
+                                    0
+                                ],
+                                [
+                                    8,
+                                    0
+                                ],
+                                [
+                                    12,
+                                    0
+                                ],
+                                [
+                                    17,
+                                    0
+                                ],
+                                [
+                                    19,
+                                    0
+                                ]
+                            ],
+                            "interpolate": false
+                        },
+                        {
+                            "type": "ScheduleDay",
+                            "identifier": "OfficeMedium BLDG_EQUIP_SCH_2013_Wkdy",
+                            "values": [
+                                0.3076738408,
+                                0.381234796,
+                                0.857778291,
+                                0.762469592,
+                                0.857778291,
+                                0.476543495,
+                                0.381234796
+                            ],
+                            "times": [
+                                [
+                                    0,
+                                    0
+                                ],
+                                [
+                                    6,
+                                    0
+                                ],
+                                [
+                                    8,
+                                    0
+                                ],
+                                [
+                                    12,
+                                    0
+                                ],
+                                [
+                                    13,
+                                    0
+                                ],
+                                [
+                                    17,
+                                    0
+                                ],
+                                [
+                                    18,
+                                    0
+                                ]
+                            ],
+                            "interpolate": false
+                        }
+                    ],
+                    "default_day_schedule": "OfficeMedium BLDG_EQUIP_SCH_2013_Sun",
+                    "schedule_rules": [
+                        {
+                            "type": "ScheduleRuleAbridged",
+                            "schedule_day": "OfficeMedium BLDG_EQUIP_SCH_2013_Wkdy",
+                            "apply_sunday": false,
+                            "apply_monday": true,
+                            "apply_tuesday": true,
+                            "apply_wednesday": true,
+                            "apply_thursday": true,
+                            "apply_friday": true,
+                            "apply_saturday": false,
+                            "start_date": [
+                                1,
+                                1
+                            ],
+                            "end_date": [
+                                12,
+                                31
+                            ]
+                        },
+                        {
+                            "type": "ScheduleRuleAbridged",
+                            "schedule_day": "OfficeMedium BLDG_EQUIP_SCH_2013_Sat",
+                            "apply_sunday": false,
+                            "apply_monday": false,
+                            "apply_tuesday": false,
+                            "apply_wednesday": false,
+                            "apply_thursday": false,
+                            "apply_friday": false,
+                            "apply_saturday": true,
+                            "start_date": [
+                                1,
+                                1
+                            ],
+                            "end_date": [
+                                12,
+                                31
+                            ]
+                        }
+                    ],
+                    "holiday_schedule": "OfficeMedium BLDG_EQUIP_SCH_2013_Sat",
+                    "summer_designday_schedule": "OfficeMedium BLDG_EQUIP_SCH_2013_SmrDsn",
+                    "winter_designday_schedule": "OfficeMedium BLDG_EQUIP_SCH_2013_WntrDsn",
+                    "schedule_type_limit": "Fractional"
+                },
+                {
+                    "type": "ScheduleRulesetAbridged",
+                    "identifier": "Generic Office Heating",
+                    "day_schedules": [
+                        {
+                            "type": "ScheduleDay",
+                            "identifier": "OfficeMedium HTGSETP_SCH_YES_OPTIMUM_Default",
+                            "values": [
+                                15.6
+                            ],
+                            "times": [
+                                [
+                                    0,
+                                    0
+                                ]
+                            ],
+                            "interpolate": false
+                        },
+                        {
+                            "type": "ScheduleDay",
+                            "identifier": "OfficeMedium HTGSETP_SCH_YES_OPTIMUM_Default_SmrDsn",
+                            "values": [
+                                15.6
+                            ],
+                            "times": [
+                                [
+                                    0,
+                                    0
+                                ]
+                            ],
+                            "interpolate": false
+                        },
+                        {
+                            "type": "ScheduleDay",
+                            "identifier": "OfficeMedium HTGSETP_SCH_YES_OPTIMUM_WntrDsn",
+                            "values": [
+                                15.6,
+                                17.6,
+                                19.6,
+                                21.0,
+                                15.6
+                            ],
+                            "times": [
+                                [
+                                    0,
+                                    0
+                                ],
+                                [
+                                    5,
+                                    0
+                                ],
+                                [
+                                    6,
+                                    0
+                                ],
+                                [
+                                    7,
+                                    0
+                                ],
+                                [
+                                    22,
+                                    0
+                                ]
+                            ],
+                            "interpolate": false
+                        },
+                        {
+                            "type": "ScheduleDay",
+                            "identifier": "OfficeMedium HTGSETP_SCH_YES_OPTIMUM_Wkdy",
+                            "values": [
+                                15.6,
+                                17.8,
+                                20.0,
+                                21.0,
+                                15.6
+                            ],
+                            "times": [
+                                [
+                                    0,
+                                    0
+                                ],
+                                [
+                                    5,
+                                    0
+                                ],
+                                [
+                                    6,
+                                    0
+                                ],
+                                [
+                                    7,
+                                    0
+                                ],
+                                [
+                                    22,
+                                    0
+                                ]
+                            ],
+                            "interpolate": false
+                        },
+                        {
+                            "type": "ScheduleDay",
+                            "identifier": "OfficeMedium HTGSETP_SCH_YES_OPTIMUM_Sat",
+                            "values": [
+                                15.6,
+                                17.8,
+                                20.0,
+                                21.0,
+                                15.6
+                            ],
+                            "times": [
+                                [
+                                    0,
+                                    0
+                                ],
+                                [
+                                    5,
+                                    0
+                                ],
+                                [
+                                    6,
+                                    0
+                                ],
+                                [
+                                    7,
+                                    0
+                                ],
+                                [
+                                    17,
+                                    0
+                                ]
+                            ],
+                            "interpolate": false
+                        }
+                    ],
+                    "default_day_schedule": "OfficeMedium HTGSETP_SCH_YES_OPTIMUM_Default",
+                    "schedule_rules": [
+                        {
+                            "type": "ScheduleRuleAbridged",
+                            "schedule_day": "OfficeMedium HTGSETP_SCH_YES_OPTIMUM_Wkdy",
+                            "apply_sunday": false,
+                            "apply_monday": true,
+                            "apply_tuesday": true,
+                            "apply_wednesday": true,
+                            "apply_thursday": true,
+                            "apply_friday": true,
+                            "apply_saturday": false,
+                            "start_date": [
+                                1,
+                                1
+                            ],
+                            "end_date": [
+                                12,
+                                31
+                            ]
+                        },
+                        {
+                            "type": "ScheduleRuleAbridged",
+                            "schedule_day": "OfficeMedium HTGSETP_SCH_YES_OPTIMUM_Sat",
+                            "apply_sunday": false,
+                            "apply_monday": false,
+                            "apply_tuesday": false,
+                            "apply_wednesday": false,
+                            "apply_thursday": false,
+                            "apply_friday": false,
+                            "apply_saturday": true,
+                            "start_date": [
+                                1,
+                                1
+                            ],
+                            "end_date": [
+                                12,
+                                31
+                            ]
+                        }
+                    ],
+                    "holiday_schedule": "OfficeMedium HTGSETP_SCH_YES_OPTIMUM_Default",
+                    "summer_designday_schedule": "OfficeMedium HTGSETP_SCH_YES_OPTIMUM_Default_SmrDsn",
+                    "winter_designday_schedule": "OfficeMedium HTGSETP_SCH_YES_OPTIMUM_WntrDsn",
+                    "schedule_type_limit": "Temperature"
+                },
+                {
+                    "type": "ScheduleRulesetAbridged",
+                    "identifier": "Generic Office Cooling",
+                    "day_schedules": [
+                        {
+                            "type": "ScheduleDay",
+                            "identifier": "OfficeMedium CLGSETP_SCH_YES_OPTIMUM_Default",
+                            "values": [
+                                26.7
+                            ],
+                            "times": [
+                                [
+                                    0,
+                                    0
+                                ]
+                            ],
+                            "interpolate": false
+                        },
+                        {
+                            "type": "ScheduleDay",
+                            "identifier": "OfficeMedium CLGSETP_SCH_YES_OPTIMUM_SmrDsn",
+                            "values": [
+                                26.7,
+                                25.7,
+                                25.0,
+                                24.0,
+                                26.7
+                            ],
+                            "times": [
+                                [
+                                    0,
+                                    0
+                                ],
+                                [
+                                    5,
+                                    0
+                                ],
+                                [
+                                    6,
+                                    0
+                                ],
+                                [
+                                    7,
+                                    0
+                                ],
+                                [
+                                    22,
+                                    0
+                                ]
+                            ],
+                            "interpolate": false
+                        },
+                        {
+                            "type": "ScheduleDay",
+                            "identifier": "OfficeMedium CLGSETP_SCH_YES_OPTIMUM_Default_WntrDsn",
+                            "values": [
+                                26.7
+                            ],
+                            "times": [
+                                [
+                                    0,
+                                    0
+                                ]
+                            ],
+                            "interpolate": false
+                        },
+                        {
+                            "type": "ScheduleDay",
+                            "identifier": "OfficeMedium CLGSETP_SCH_YES_OPTIMUM_Wkdy",
+                            "values": [
+                                26.7,
+                                25.6,
+                                25.0,
+                                24.0,
+                                26.7
+                            ],
+                            "times": [
+                                [
+                                    0,
+                                    0
+                                ],
+                                [
+                                    5,
+                                    0
+                                ],
+                                [
+                                    6,
+                                    0
+                                ],
+                                [
+                                    7,
+                                    0
+                                ],
+                                [
+                                    22,
+                                    0
+                                ]
+                            ],
+                            "interpolate": false
+                        },
+                        {
+                            "type": "ScheduleDay",
+                            "identifier": "OfficeMedium CLGSETP_SCH_YES_OPTIMUM_Sat",
+                            "values": [
+                                26.7,
+                                25.7,
+                                25.0,
+                                24.0,
+                                26.7
+                            ],
+                            "times": [
+                                [
+                                    0,
+                                    0
+                                ],
+                                [
+                                    5,
+                                    0
+                                ],
+                                [
+                                    6,
+                                    0
+                                ],
+                                [
+                                    7,
+                                    0
+                                ],
+                                [
+                                    17,
+                                    0
+                                ]
+                            ],
+                            "interpolate": false
+                        }
+                    ],
+                    "default_day_schedule": "OfficeMedium CLGSETP_SCH_YES_OPTIMUM_Default",
+                    "schedule_rules": [
+                        {
+                            "type": "ScheduleRuleAbridged",
+                            "schedule_day": "OfficeMedium CLGSETP_SCH_YES_OPTIMUM_Wkdy",
+                            "apply_sunday": false,
+                            "apply_monday": true,
+                            "apply_tuesday": true,
+                            "apply_wednesday": true,
+                            "apply_thursday": true,
+                            "apply_friday": true,
+                            "apply_saturday": false,
+                            "start_date": [
+                                1,
+                                1
+                            ],
+                            "end_date": [
+                                12,
+                                31
+                            ]
+                        },
+                        {
+                            "type": "ScheduleRuleAbridged",
+                            "schedule_day": "OfficeMedium CLGSETP_SCH_YES_OPTIMUM_Sat",
+                            "apply_sunday": false,
+                            "apply_monday": false,
+                            "apply_tuesday": false,
+                            "apply_wednesday": false,
+                            "apply_thursday": false,
+                            "apply_friday": false,
+                            "apply_saturday": true,
+                            "start_date": [
+                                1,
+                                1
+                            ],
+                            "end_date": [
+                                12,
+                                31
+                            ]
+                        }
+                    ],
+                    "holiday_schedule": "OfficeMedium CLGSETP_SCH_YES_OPTIMUM_Default",
+                    "summer_designday_schedule": "OfficeMedium CLGSETP_SCH_YES_OPTIMUM_SmrDsn",
+                    "winter_designday_schedule": "OfficeMedium CLGSETP_SCH_YES_OPTIMUM_Default_WntrDsn",
+                    "schedule_type_limit": "Temperature"
+                },
+                {
+                    "type": "ScheduleRulesetAbridged",
+                    "identifier": "Seated Adult Activity",
+                    "day_schedules": [
+                        {
+                            "type": "ScheduleDay",
+                            "identifier": "Seated Adult Activity_Day Schedule",
+                            "values": [
+                                120.0
+                            ],
+                            "times": [
+                                [
+                                    0,
+                                    0
+                                ]
+                            ],
+                            "interpolate": false
+                        }
+                    ],
+                    "default_day_schedule": "Seated Adult Activity_Day Schedule",
+                    "schedule_type_limit": "Activity Level"
+                },
+                {
+                    "type": "ScheduleRulesetAbridged",
+                    "identifier": "Generic Office Lighting",
+                    "day_schedules": [
+                        {
+                            "type": "ScheduleDay",
+                            "identifier": "OfficeMedium BLDG_LIGHT_SCH_2013_Sun",
+                            "values": [
+                                0.05,
+                                0.04311628,
+                                0.05
+                            ],
+                            "times": [
+                                [
+                                    0,
+                                    0
+                                ],
+                                [
+                                    6,
+                                    0
+                                ],
+                                [
+                                    18,
+                                    0
+                                ]
+                            ],
+                            "interpolate": false
+                        },
+                        {
+                            "type": "ScheduleDay",
+                            "identifier": "OfficeMedium BLDG_LIGHT_SCH_2013_SmrDsn",
+                            "values": [
+                                1.0
+                            ],
+                            "times": [
+                                [
+                                    0,
+                                    0
+                                ]
+                            ],
+                            "interpolate": false
+                        },
+                        {
+                            "type": "ScheduleDay",
+                            "identifier": "OfficeMedium BLDG_LIGHT_SCH_2013_WntrDsn",
+                            "values": [
+                                0.0
+                            ],
+                            "times": [
+                                [
+                                    0,
+                                    0
+                                ]
+                            ],
+                            "interpolate": false
+                        },
+                        {
+                            "type": "ScheduleDay",
+                            "identifier": "OfficeMedium BLDG_LIGHT_SCH_2013_Sat",
+                            "values": [
+                                0.05,
+                                0.08623256,
+                                0.25869768,
+                                0.12934884,
+                                0.04311628,
+                                0.05
+                            ],
+                            "times": [
+                                [
+                                    0,
+                                    0
+                                ],
+                                [
+                                    6,
+                                    0
+                                ],
+                                [
+                                    8,
+                                    0
+                                ],
+                                [
+                                    12,
+                                    0
+                                ],
+                                [
+                                    17,
+                                    0
+                                ],
+                                [
+                                    19,
+                                    0
+                                ]
+                            ],
+                            "interpolate": false
+                        },
+                        {
+                            "type": "ScheduleDay",
+                            "identifier": "OfficeMedium BLDG_LIGHT_SCH_2013_Wkdy",
+                            "values": [
+                                0.05,
+                                0.1,
+                                0.08623256,
+                                0.25869768,
+                                0.77609304,
+                                0.4311628,
+                                0.25869768,
+                                0.17246512,
+                                0.08623256,
+                                0.04311628
+                            ],
+                            "times": [
+                                [
+                                    0,
+                                    0
+                                ],
+                                [
+                                    5,
+                                    0
+                                ],
+                                [
+                                    6,
+                                    0
+                                ],
+                                [
+                                    7,
+                                    0
+                                ],
+                                [
+                                    8,
+                                    0
+                                ],
+                                [
+                                    17,
+                                    0
+                                ],
+                                [
+                                    18,
+                                    0
+                                ],
+                                [
+                                    20,
+                                    0
+                                ],
+                                [
+                                    22,
+                                    0
+                                ],
+                                [
+                                    23,
+                                    0
+                                ]
+                            ],
+                            "interpolate": false
+                        }
+                    ],
+                    "default_day_schedule": "OfficeMedium BLDG_LIGHT_SCH_2013_Sun",
+                    "schedule_rules": [
+                        {
+                            "type": "ScheduleRuleAbridged",
+                            "schedule_day": "OfficeMedium BLDG_LIGHT_SCH_2013_Wkdy",
+                            "apply_sunday": false,
+                            "apply_monday": true,
+                            "apply_tuesday": true,
+                            "apply_wednesday": true,
+                            "apply_thursday": true,
+                            "apply_friday": true,
+                            "apply_saturday": false,
+                            "start_date": [
+                                1,
+                                1
+                            ],
+                            "end_date": [
+                                12,
+                                31
+                            ]
+                        },
+                        {
+                            "type": "ScheduleRuleAbridged",
+                            "schedule_day": "OfficeMedium BLDG_LIGHT_SCH_2013_Sat",
+                            "apply_sunday": false,
+                            "apply_monday": false,
+                            "apply_tuesday": false,
+                            "apply_wednesday": false,
+                            "apply_thursday": false,
+                            "apply_friday": false,
+                            "apply_saturday": true,
+                            "start_date": [
+                                1,
+                                1
+                            ],
+                            "end_date": [
+                                12,
+                                31
+                            ]
+                        }
+                    ],
+                    "holiday_schedule": "OfficeMedium BLDG_LIGHT_SCH_2013_Sat",
+                    "summer_designday_schedule": "OfficeMedium BLDG_LIGHT_SCH_2013_SmrDsn",
+                    "winter_designday_schedule": "OfficeMedium BLDG_LIGHT_SCH_2013_WntrDsn",
+                    "schedule_type_limit": "Fractional"
+                }
+            ],
+            "schedule_type_limits": [
+                {
+                    "type": "ScheduleTypeLimit",
+                    "identifier": "Fractional",
+                    "lower_limit": 0.0,
+                    "upper_limit": 1.0,
+                    "numeric_type": "Continuous",
+                    "unit_type": "Dimensionless"
+                },
+                {
+                    "type": "ScheduleTypeLimit",
+                    "identifier": "Activity Level",
+                    "lower_limit": 0.0,
+                    "upper_limit": {
+                        "type": "NoLimit"
+                    },
+                    "numeric_type": "Continuous",
+                    "unit_type": "ActivityLevel"
+                },
+                {
+                    "type": "ScheduleTypeLimit",
+                    "identifier": "Temperature",
+                    "lower_limit": -273.15,
+                    "upper_limit": {
+                        "type": "NoLimit"
+                    },
+                    "numeric_type": "Continuous",
+                    "unit_type": "Temperature"
+                }
+            ]
+        }
+    },
+    "rooms": [
+        {
+            "type": "Room",
+            "identifier": "First_Floor",
+            "display_name": "First_Floor",
+            "properties": {
+                "type": "RoomPropertiesAbridged",
+                "energy": {
+                    "type": "RoomEnergyPropertiesAbridged",
+                    "program_type": "Generic Office Program",
+                    "hvac": "FCU System with DOAS Heat Recovery"
+                }
+            },
+            "faces": [
+                {
+                    "type": "Face",
+                    "identifier": "First_Floor_Bottom",
+                    "display_name": "First_Floor_Bottom",
+                    "properties": {
+                        "type": "FacePropertiesAbridged",
+                        "energy": {
+                            "type": "FaceEnergyPropertiesAbridged"
+                        }
+                    },
+                    "geometry": {
+                        "type": "Face3D",
+                        "boundary": [
+                            [
+                                0.0,
+                                0.0,
+                                0.0
+                            ],
+                            [
+                                0.0,
+                                10.0,
+                                0.0
+                            ],
+                            [
+                                10.0,
+                                10.0,
+                                0.0
+                            ],
+                            [
+                                10.0,
+                                0.0,
+                                0.0
+                            ]
+                        ]
+                    },
+                    "face_type": "Floor",
+                    "boundary_condition": {
+                        "type": "Ground"
+                    }
+                },
+                {
+                    "type": "Face",
+                    "identifier": "First_Floor_Front",
+                    "display_name": "First_Floor_Front",
+                    "properties": {
+                        "type": "FacePropertiesAbridged",
+                        "energy": {
+                            "type": "FaceEnergyPropertiesAbridged"
+                        }
+                    },
+                    "geometry": {
+                        "type": "Face3D",
+                        "boundary": [
+                            [
+                                10.0,
+                                10.0,
+                                3.0
+                            ],
+                            [
+                                10.0,
+                                10.0,
+                                0.0
+                            ],
+                            [
+                                0.0,
+                                10.0,
+                                0.0
+                            ],
+                            [
+                                0.0,
+                                10.0,
+                                3.0
+                            ]
+                        ]
+                    },
+                    "face_type": "Wall",
+                    "boundary_condition": {
+                        "type": "Outdoors",
+                        "sun_exposure": true,
+                        "wind_exposure": true,
+                        "view_factor": {
+                            "type": "Autocalculate"
+                        }
+                    },
+                    "apertures": [
+                        {
+                            "type": "Aperture",
+                            "identifier": "First_Floor_Front_Glz0",
+                            "display_name": "First_Floor_Front_Glz0",
+                            "properties": {
+                                "type": "AperturePropertiesAbridged",
+                                "energy": {
+                                    "type": "ApertureEnergyPropertiesAbridged"
+                                }
+                            },
+                            "geometry": {
+                                "type": "Face3D",
+                                "boundary": [
+                                    [
+                                        7.23606797749979,
+                                        10.0,
+                                        2.170820393249937
+                                    ],
+                                    [
+                                        7.23606797749979,
+                                        10.0,
+                                        0.8291796067500631
+                                    ],
+                                    [
+                                        2.76393202250021,
+                                        10.0,
+                                        0.8291796067500631
+                                    ],
+                                    [
+                                        2.76393202250021,
+                                        10.0,
+                                        2.170820393249937
+                                    ]
+                                ]
+                            },
+                            "is_operable": false,
+                            "boundary_condition": {
+                                "type": "Outdoors",
+                                "sun_exposure": true,
+                                "wind_exposure": true,
+                                "view_factor": {
+                                    "type": "Autocalculate"
+                                }
+                            }
+                        }
+                    ]
+                },
+                {
+                    "type": "Face",
+                    "identifier": "First_Floor_Right",
+                    "display_name": "First_Floor_Right",
+                    "properties": {
+                        "type": "FacePropertiesAbridged",
+                        "energy": {
+                            "type": "FaceEnergyPropertiesAbridged"
+                        }
+                    },
+                    "geometry": {
+                        "type": "Face3D",
+                        "boundary": [
+                            [
+                                10.0,
+                                0.0,
+                                3.0
+                            ],
+                            [
+                                10.0,
+                                0.0,
+                                0.0
+                            ],
+                            [
+                                10.0,
+                                10.0,
+                                0.0
+                            ],
+                            [
+                                10.0,
+                                10.0,
+                                3.0
+                            ]
+                        ]
+                    },
+                    "face_type": "Wall",
+                    "boundary_condition": {
+                        "type": "Outdoors",
+                        "sun_exposure": true,
+                        "wind_exposure": true,
+                        "view_factor": {
+                            "type": "Autocalculate"
+                        }
+                    },
+                    "apertures": [
+                        {
+                            "type": "Aperture",
+                            "identifier": "First_Floor_Right_Glz0",
+                            "display_name": "First_Floor_Right_Glz0",
+                            "properties": {
+                                "type": "AperturePropertiesAbridged",
+                                "energy": {
+                                    "type": "ApertureEnergyPropertiesAbridged"
+                                }
+                            },
+                            "geometry": {
+                                "type": "Face3D",
+                                "boundary": [
+                                    [
+                                        10.0,
+                                        2.76393202250021,
+                                        2.170820393249937
+                                    ],
+                                    [
+                                        10.0,
+                                        2.76393202250021,
+                                        0.8291796067500631
+                                    ],
+                                    [
+                                        10.0,
+                                        7.23606797749979,
+                                        0.8291796067500631
+                                    ],
+                                    [
+                                        10.0,
+                                        7.23606797749979,
+                                        2.170820393249937
+                                    ]
+                                ]
+                            },
+                            "is_operable": false,
+                            "boundary_condition": {
+                                "type": "Outdoors",
+                                "sun_exposure": true,
+                                "wind_exposure": true,
+                                "view_factor": {
+                                    "type": "Autocalculate"
+                                }
+                            }
+                        }
+                    ]
+                },
+                {
+                    "type": "Face",
+                    "identifier": "First_Floor_Back",
+                    "display_name": "First_Floor_Back",
+                    "properties": {
+                        "type": "FacePropertiesAbridged",
+                        "energy": {
+                            "type": "FaceEnergyPropertiesAbridged"
+                        }
+                    },
+                    "geometry": {
+                        "type": "Face3D",
+                        "boundary": [
+                            [
+                                0.0,
+                                0.0,
+                                3.0
+                            ],
+                            [
+                                0.0,
+                                0.0,
+                                0.0
+                            ],
+                            [
+                                10.0,
+                                0.0,
+                                0.0
+                            ],
+                            [
+                                10.0,
+                                0.0,
+                                3.0
+                            ]
+                        ]
+                    },
+                    "face_type": "Wall",
+                    "boundary_condition": {
+                        "type": "Outdoors",
+                        "sun_exposure": true,
+                        "wind_exposure": true,
+                        "view_factor": {
+                            "type": "Autocalculate"
+                        }
+                    },
+                    "apertures": [
+                        {
+                            "type": "Aperture",
+                            "identifier": "First_Floor_Back_Glz0",
+                            "display_name": "First_Floor_Back_Glz0",
+                            "properties": {
+                                "type": "AperturePropertiesAbridged",
+                                "energy": {
+                                    "type": "ApertureEnergyPropertiesAbridged"
+                                }
+                            },
+                            "geometry": {
+                                "type": "Face3D",
+                                "boundary": [
+                                    [
+                                        2.76393202250021,
+                                        0.0,
+                                        2.170820393249937
+                                    ],
+                                    [
+                                        2.76393202250021,
+                                        0.0,
+                                        0.8291796067500631
+                                    ],
+                                    [
+                                        7.23606797749979,
+                                        0.0,
+                                        0.8291796067500631
+                                    ],
+                                    [
+                                        7.23606797749979,
+                                        0.0,
+                                        2.170820393249937
+                                    ]
+                                ]
+                            },
+                            "is_operable": false,
+                            "boundary_condition": {
+                                "type": "Outdoors",
+                                "sun_exposure": true,
+                                "wind_exposure": true,
+                                "view_factor": {
+                                    "type": "Autocalculate"
+                                }
+                            }
+                        }
+                    ]
+                },
+                {
+                    "type": "Face",
+                    "identifier": "First_Floor_Left",
+                    "display_name": "First_Floor_Left",
+                    "properties": {
+                        "type": "FacePropertiesAbridged",
+                        "energy": {
+                            "type": "FaceEnergyPropertiesAbridged"
+                        }
+                    },
+                    "geometry": {
+                        "type": "Face3D",
+                        "boundary": [
+                            [
+                                0.0,
+                                10.0,
+                                3.0
+                            ],
+                            [
+                                0.0,
+                                10.0,
+                                0.0
+                            ],
+                            [
+                                0.0,
+                                0.0,
+                                0.0
+                            ],
+                            [
+                                0.0,
+                                0.0,
+                                3.0
+                            ]
+                        ]
+                    },
+                    "face_type": "Wall",
+                    "boundary_condition": {
+                        "type": "Outdoors",
+                        "sun_exposure": true,
+                        "wind_exposure": true,
+                        "view_factor": {
+                            "type": "Autocalculate"
+                        }
+                    },
+                    "apertures": [
+                        {
+                            "type": "Aperture",
+                            "identifier": "First_Floor_Left_Glz0",
+                            "display_name": "First_Floor_Left_Glz0",
+                            "properties": {
+                                "type": "AperturePropertiesAbridged",
+                                "energy": {
+                                    "type": "ApertureEnergyPropertiesAbridged"
+                                }
+                            },
+                            "geometry": {
+                                "type": "Face3D",
+                                "boundary": [
+                                    [
+                                        0.0,
+                                        7.23606797749979,
+                                        2.170820393249937
+                                    ],
+                                    [
+                                        0.0,
+                                        7.23606797749979,
+                                        0.8291796067500631
+                                    ],
+                                    [
+                                        0.0,
+                                        2.76393202250021,
+                                        0.8291796067500631
+                                    ],
+                                    [
+                                        0.0,
+                                        2.76393202250021,
+                                        2.170820393249937
+                                    ]
+                                ]
+                            },
+                            "is_operable": false,
+                            "boundary_condition": {
+                                "type": "Outdoors",
+                                "sun_exposure": true,
+                                "wind_exposure": true,
+                                "view_factor": {
+                                    "type": "Autocalculate"
+                                }
+                            }
+                        }
+                    ]
+                },
+                {
+                    "type": "Face",
+                    "identifier": "First_Floor_Top",
+                    "display_name": "First_Floor_Top",
+                    "properties": {
+                        "type": "FacePropertiesAbridged",
+                        "energy": {
+                            "type": "FaceEnergyPropertiesAbridged"
+                        }
+                    },
+                    "geometry": {
+                        "type": "Face3D",
+                        "boundary": [
+                            [
+                                10.0,
+                                0.0,
+                                3.0
+                            ],
+                            [
+                                10.0,
+                                10.0,
+                                3.0
+                            ],
+                            [
+                                0.0,
+                                10.0,
+                                3.0
+                            ],
+                            [
+                                0.0,
+                                0.0,
+                                3.0
+                            ]
+                        ]
+                    },
+                    "face_type": "RoofCeiling",
+                    "boundary_condition": {
+                        "type": "Surface",
+                        "boundary_condition_objects": [
+                            "Second_Floor_Bottom",
+                            "Second_Floor"
+                        ]
+                    }
+                }
+            ]
+        },
+        {
+            "type": "Room",
+            "identifier": "Second_Floor",
+            "display_name": "Second_Floor",
+            "properties": {
+                "type": "RoomPropertiesAbridged",
+                "energy": {
+                    "type": "RoomEnergyPropertiesAbridged",
+                    "program_type": "Generic Office Program",
+                    "hvac": "FCU System with DOAS Heat Recovery"
+                }
+            },
+            "faces": [
+                {
+                    "type": "Face",
+                    "identifier": "Second_Floor_Bottom",
+                    "display_name": "Second_Floor_Bottom",
+                    "properties": {
+                        "type": "FacePropertiesAbridged",
+                        "energy": {
+                            "type": "FaceEnergyPropertiesAbridged"
+                        }
+                    },
+                    "geometry": {
+                        "type": "Face3D",
+                        "boundary": [
+                            [
+                                0.0,
+                                0.0,
+                                3.0
+                            ],
+                            [
+                                0.0,
+                                10.0,
+                                3.0
+                            ],
+                            [
+                                10.0,
+                                10.0,
+                                3.0
+                            ],
+                            [
+                                10.0,
+                                0.0,
+                                3.0
+                            ]
+                        ]
+                    },
+                    "face_type": "Floor",
+                    "boundary_condition": {
+                        "type": "Surface",
+                        "boundary_condition_objects": [
+                            "First_Floor_Top",
+                            "First_Floor"
+                        ]
+                    }
+                },
+                {
+                    "type": "Face",
+                    "identifier": "Second_Floor_Front",
+                    "display_name": "Second_Floor_Front",
+                    "properties": {
+                        "type": "FacePropertiesAbridged",
+                        "energy": {
+                            "type": "FaceEnergyPropertiesAbridged"
+                        }
+                    },
+                    "geometry": {
+                        "type": "Face3D",
+                        "boundary": [
+                            [
+                                10.0,
+                                10.0,
+                                6.0
+                            ],
+                            [
+                                10.0,
+                                10.0,
+                                3.0
+                            ],
+                            [
+                                0.0,
+                                10.0,
+                                3.0
+                            ],
+                            [
+                                0.0,
+                                10.0,
+                                6.0
+                            ]
+                        ]
+                    },
+                    "face_type": "Wall",
+                    "boundary_condition": {
+                        "type": "Outdoors",
+                        "sun_exposure": true,
+                        "wind_exposure": true,
+                        "view_factor": {
+                            "type": "Autocalculate"
+                        }
+                    },
+                    "apertures": [
+                        {
+                            "type": "Aperture",
+                            "identifier": "Second_Floor_Front_Glz0",
+                            "display_name": "Second_Floor_Front_Glz0",
+                            "properties": {
+                                "type": "AperturePropertiesAbridged",
+                                "energy": {
+                                    "type": "ApertureEnergyPropertiesAbridged"
+                                }
+                            },
+                            "geometry": {
+                                "type": "Face3D",
+                                "boundary": [
+                                    [
+                                        7.23606797749979,
+                                        10.0,
+                                        5.170820393249937
+                                    ],
+                                    [
+                                        7.23606797749979,
+                                        10.0,
+                                        3.829179606750063
+                                    ],
+                                    [
+                                        2.76393202250021,
+                                        10.0,
+                                        3.829179606750063
+                                    ],
+                                    [
+                                        2.76393202250021,
+                                        10.0,
+                                        5.170820393249937
+                                    ]
+                                ]
+                            },
+                            "is_operable": false,
+                            "boundary_condition": {
+                                "type": "Outdoors",
+                                "sun_exposure": true,
+                                "wind_exposure": true,
+                                "view_factor": {
+                                    "type": "Autocalculate"
+                                }
+                            }
+                        }
+                    ]
+                },
+                {
+                    "type": "Face",
+                    "identifier": "Second_Floor_Right",
+                    "display_name": "Second_Floor_Right",
+                    "properties": {
+                        "type": "FacePropertiesAbridged",
+                        "energy": {
+                            "type": "FaceEnergyPropertiesAbridged"
+                        }
+                    },
+                    "geometry": {
+                        "type": "Face3D",
+                        "boundary": [
+                            [
+                                10.0,
+                                0.0,
+                                6.0
+                            ],
+                            [
+                                10.0,
+                                0.0,
+                                3.0
+                            ],
+                            [
+                                10.0,
+                                10.0,
+                                3.0
+                            ],
+                            [
+                                10.0,
+                                10.0,
+                                6.0
+                            ]
+                        ]
+                    },
+                    "face_type": "Wall",
+                    "boundary_condition": {
+                        "type": "Outdoors",
+                        "sun_exposure": true,
+                        "wind_exposure": true,
+                        "view_factor": {
+                            "type": "Autocalculate"
+                        }
+                    },
+                    "apertures": [
+                        {
+                            "type": "Aperture",
+                            "identifier": "Second_Floor_Right_Glz0",
+                            "display_name": "Second_Floor_Right_Glz0",
+                            "properties": {
+                                "type": "AperturePropertiesAbridged",
+                                "energy": {
+                                    "type": "ApertureEnergyPropertiesAbridged"
+                                }
+                            },
+                            "geometry": {
+                                "type": "Face3D",
+                                "boundary": [
+                                    [
+                                        10.0,
+                                        2.76393202250021,
+                                        5.170820393249937
+                                    ],
+                                    [
+                                        10.0,
+                                        2.76393202250021,
+                                        3.829179606750063
+                                    ],
+                                    [
+                                        10.0,
+                                        7.23606797749979,
+                                        3.829179606750063
+                                    ],
+                                    [
+                                        10.0,
+                                        7.23606797749979,
+                                        5.170820393249937
+                                    ]
+                                ]
+                            },
+                            "is_operable": false,
+                            "boundary_condition": {
+                                "type": "Outdoors",
+                                "sun_exposure": true,
+                                "wind_exposure": true,
+                                "view_factor": {
+                                    "type": "Autocalculate"
+                                }
+                            }
+                        }
+                    ]
+                },
+                {
+                    "type": "Face",
+                    "identifier": "Second_Floor_Back",
+                    "display_name": "Second_Floor_Back",
+                    "properties": {
+                        "type": "FacePropertiesAbridged",
+                        "energy": {
+                            "type": "FaceEnergyPropertiesAbridged"
+                        }
+                    },
+                    "geometry": {
+                        "type": "Face3D",
+                        "boundary": [
+                            [
+                                0.0,
+                                0.0,
+                                6.0
+                            ],
+                            [
+                                0.0,
+                                0.0,
+                                3.0
+                            ],
+                            [
+                                10.0,
+                                0.0,
+                                3.0
+                            ],
+                            [
+                                10.0,
+                                0.0,
+                                6.0
+                            ]
+                        ]
+                    },
+                    "face_type": "Wall",
+                    "boundary_condition": {
+                        "type": "Outdoors",
+                        "sun_exposure": true,
+                        "wind_exposure": true,
+                        "view_factor": {
+                            "type": "Autocalculate"
+                        }
+                    },
+                    "apertures": [
+                        {
+                            "type": "Aperture",
+                            "identifier": "Second_Floor_Back_Glz0",
+                            "display_name": "Second_Floor_Back_Glz0",
+                            "properties": {
+                                "type": "AperturePropertiesAbridged",
+                                "energy": {
+                                    "type": "ApertureEnergyPropertiesAbridged"
+                                }
+                            },
+                            "geometry": {
+                                "type": "Face3D",
+                                "boundary": [
+                                    [
+                                        2.76393202250021,
+                                        0.0,
+                                        5.170820393249937
+                                    ],
+                                    [
+                                        2.76393202250021,
+                                        0.0,
+                                        3.829179606750063
+                                    ],
+                                    [
+                                        7.23606797749979,
+                                        0.0,
+                                        3.829179606750063
+                                    ],
+                                    [
+                                        7.23606797749979,
+                                        0.0,
+                                        5.170820393249937
+                                    ]
+                                ]
+                            },
+                            "is_operable": false,
+                            "boundary_condition": {
+                                "type": "Outdoors",
+                                "sun_exposure": true,
+                                "wind_exposure": true,
+                                "view_factor": {
+                                    "type": "Autocalculate"
+                                }
+                            }
+                        }
+                    ]
+                },
+                {
+                    "type": "Face",
+                    "identifier": "Second_Floor_Left",
+                    "display_name": "Second_Floor_Left",
+                    "properties": {
+                        "type": "FacePropertiesAbridged",
+                        "energy": {
+                            "type": "FaceEnergyPropertiesAbridged"
+                        }
+                    },
+                    "geometry": {
+                        "type": "Face3D",
+                        "boundary": [
+                            [
+                                0.0,
+                                10.0,
+                                6.0
+                            ],
+                            [
+                                0.0,
+                                10.0,
+                                3.0
+                            ],
+                            [
+                                0.0,
+                                0.0,
+                                3.0
+                            ],
+                            [
+                                0.0,
+                                0.0,
+                                6.0
+                            ]
+                        ]
+                    },
+                    "face_type": "Wall",
+                    "boundary_condition": {
+                        "type": "Outdoors",
+                        "sun_exposure": true,
+                        "wind_exposure": true,
+                        "view_factor": {
+                            "type": "Autocalculate"
+                        }
+                    },
+                    "apertures": [
+                        {
+                            "type": "Aperture",
+                            "identifier": "Second_Floor_Left_Glz0",
+                            "display_name": "Second_Floor_Left_Glz0",
+                            "properties": {
+                                "type": "AperturePropertiesAbridged",
+                                "energy": {
+                                    "type": "ApertureEnergyPropertiesAbridged"
+                                }
+                            },
+                            "geometry": {
+                                "type": "Face3D",
+                                "boundary": [
+                                    [
+                                        0.0,
+                                        7.23606797749979,
+                                        5.170820393249937
+                                    ],
+                                    [
+                                        0.0,
+                                        7.23606797749979,
+                                        3.829179606750063
+                                    ],
+                                    [
+                                        0.0,
+                                        2.76393202250021,
+                                        3.829179606750063
+                                    ],
+                                    [
+                                        0.0,
+                                        2.76393202250021,
+                                        5.170820393249937
+                                    ]
+                                ]
+                            },
+                            "is_operable": false,
+                            "boundary_condition": {
+                                "type": "Outdoors",
+                                "sun_exposure": true,
+                                "wind_exposure": true,
+                                "view_factor": {
+                                    "type": "Autocalculate"
+                                }
+                            }
+                        }
+                    ]
+                },
+                {
+                    "type": "Face",
+                    "identifier": "Second_Floor_Top",
+                    "display_name": "Second_Floor_Top",
+                    "properties": {
+                        "type": "FacePropertiesAbridged",
+                        "energy": {
+                            "type": "FaceEnergyPropertiesAbridged"
+                        }
+                    },
+                    "geometry": {
+                        "type": "Face3D",
+                        "boundary": [
+                            [
+                                10.0,
+                                0.0,
+                                6.0
+                            ],
+                            [
+                                10.0,
+                                10.0,
+                                6.0
+                            ],
+                            [
+                                0.0,
+                                10.0,
+                                6.0
+                            ],
+                            [
+                                0.0,
+                                0.0,
+                                6.0
+                            ]
+                        ]
+                    },
+                    "face_type": "RoofCeiling",
+                    "boundary_condition": {
+                        "type": "Outdoors",
+                        "sun_exposure": true,
+                        "wind_exposure": true,
+                        "view_factor": {
+                            "type": "Autocalculate"
+                        }
+                    }
+                }
+            ]
+        }
+    ],
+    "version": "1.35.1"
+}

--- a/scripts/sample_hvac.py
+++ b/scripts/sample_hvac.py
@@ -1,5 +1,8 @@
 # coding=utf-8
 from honeybee_energy.hvac.idealair import IdealAirSystem
+from honeybee_energy.hvac.allair.vav import VAV
+from honeybee_energy.hvac.doas.fcu import FCUwithDOAS
+from honeybee_energy.hvac.heatcool.windowac import WindowAC
 from honeybee_energy.schedule.day import ScheduleDay
 from honeybee_energy.schedule.ruleset import ScheduleRuleset
 import honeybee_energy.lib.scheduletypelimits as schedule_types
@@ -38,10 +41,40 @@ def ideal_air_detailed(directory):
         json.dump(ideal_air.to_dict(abridged=True), fp, indent=4)
 
 
+def vav_template(directory):
+    vav_sys = VAV('VAV System with Glycol Loop')
+    vav_sys.vintage = '90.1-2010'
+    vav_sys.economizer_type = 'DifferentialDryBulb'
+    vav_sys.sensible_heat_recovery = 0.55
+    vav_sys.latent_heat_recovery = 0
+    dest_file = os.path.join(directory, 'vav_template.json')
+    with open(dest_file, 'w') as fp:
+        json.dump(vav_sys.to_dict(), fp, indent=4)
+
+
+def fcu_with_doas_template(directory):
+    fcu_sys = FCUwithDOAS('FCU System with DOAS Enthalpy Wheel')
+    fcu_sys.sensible_heat_recovery = 0.81
+    fcu_sys.latent_heat_recovery = 0.67
+    dest_file = os.path.join(directory, 'fcu_with_doas_template.json')
+    with open(dest_file, 'w') as fp:
+        json.dump(fcu_sys.to_dict(), fp, indent=4)
+
+
+def window_ac_with_baseboard_template(directory):
+    ac_sys = WindowAC('FCU System with DOAS Heat Recovery')
+    ac_sys.equipment_type = 'Window AC with baseboard gas boiler'
+    dest_file = os.path.join(directory, 'window_ac_with_baseboard_template.json')
+    with open(dest_file, 'w') as fp:
+        json.dump(ac_sys.to_dict(), fp, indent=4)
+
+
 # run all functions within the file
 master_dir = os.path.split(os.path.dirname(__file__))[0]
 sample_directory = os.path.join(master_dir, 'samples', 'hvac')
 
 ideal_air_default(sample_directory)
 ideal_air_detailed(sample_directory)
-
+vav_template(sample_directory)
+fcu_with_doas_template(sample_directory)
+window_ac_with_baseboard_template(sample_directory)

--- a/tests/test_hvac.py
+++ b/tests/test_hvac.py
@@ -1,4 +1,7 @@
-from honeybee_schema.energy.hvac import IdealAirSystemAbridged
+from honeybee_schema.energy.hvac.idealair import IdealAirSystemAbridged
+from honeybee_schema.energy.hvac.allair import VAV
+from honeybee_schema.energy.hvac.doas import FCUwithDOAS
+from honeybee_schema.energy.hvac.heatcool import WindowAC
 import os
 
 # target folder where all of the samples live
@@ -14,3 +17,18 @@ def test_ideal_air_default():
 def test_ideal_air_detailed():
     file_path = os.path.join(target_folder, 'ideal_air_detailed.json')
     IdealAirSystemAbridged.parse_file(file_path)
+
+
+def test_vav_template():
+    file_path = os.path.join(target_folder, 'vav_template.json')
+    VAV.parse_file(file_path)
+
+
+def test_fcu_with_doas_template():
+    file_path = os.path.join(target_folder, 'fcu_with_doas_template.json')
+    FCUwithDOAS.parse_file(file_path)
+
+
+def test_window_ac_with_baseboard_template():
+    file_path = os.path.join(target_folder, 'window_ac_with_baseboard_template.json')
+    WindowAC.parse_file(file_path)

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -58,6 +58,21 @@ def test_model_energy_window_ventilation():
     Model.parse_file(file_path)
 
 
+def test_model_energy_allair_hvac():
+    file_path = os.path.join(target_folder, 'model_energy_allair_hvac.json')
+    Model.parse_file(file_path)
+
+
+def test_model_energy_doas_hvac():
+    file_path = os.path.join(target_folder, 'model_energy_doas_hvac.json')
+    Model.parse_file(file_path)
+
+
+def test_model_energy_window_ac():
+    file_path = os.path.join(target_folder, 'model_energy_window_ac.json')
+    Model.parse_file(file_path)
+
+
 def test_model_5vertex_sub_faces():
     file_path = os.path.join(target_folder, 'model_5vertex_sub_faces.json')
     Model.parse_file(file_path)


### PR DESCRIPTION
This commit adds modules and classes for the ~120 HVAC templates that are available in the OpenStudio standards gem.

@MingboPeng  and @mostaphaRoudsari , please let me know any comments that you have.
I'll be adding some samples and tests soon but, right now, it's just the pure pydantic stuff.