### PR TITLE
fix(ventcool): Set default discharge coefficient to 0.45 for deltaHnpl

### DIFF
--- a/honeybee_schema/energy/ventcool.py
+++ b/honeybee_schema/energy/ventcool.py
@@ -85,15 +85,15 @@ class VentilationOpening(NoExtraBaseModel):
     )
 
     discharge_coefficient: float = Field(
-        0.17,
+        0.45,
         ge=0,
         le=1,
         description='A number that will be multipled by the area of the window in the '
         'stack (buoyancy-driven) part of the equation to account for additional '
         'friction from window geometry, insect screens, etc. Typical values include '
-        '0.17, for unobstructed windows with insect screens and 0.25 for unobstructed '
-        'windows without insect screens. This value should be lowered if windows are '
-        'of an awning or casement type and not allowed to fully open.'
+        '0.45, for unobstructed windows WITH insect screens and 0.65 for unobstructed '
+        'windows WITHOUT insect screens. This value should be lowered if windows are '
+        'of an awning or casement type and are not allowed to fully open.'
     )
 
     wind_cross_vent: bool = Field(

--- a/samples/model/model_energy_window_ventilation.json
+++ b/samples/model/model_energy_window_ventilation.json
@@ -244,7 +244,7 @@
                                         "type": "VentilationOpening",
                                         "fraction_area_operable": 0.5,
                                         "fraction_height_operable": 1.0,
-                                        "discharge_coefficient": 0.17,
+                                        "discharge_coefficient": 0.45,
                                         "wind_cross_vent": true
                                     }
                                 }
@@ -388,7 +388,7 @@
                                         "type": "VentilationOpening",
                                         "fraction_area_operable": 0.5,
                                         "fraction_height_operable": 1.0,
-                                        "discharge_coefficient": 0.17,
+                                        "discharge_coefficient": 0.45,
                                         "wind_cross_vent": true
                                     }
                                 }

--- a/samples/ventcool/ventilation_opening_default.json
+++ b/samples/ventcool/ventilation_opening_default.json
@@ -2,6 +2,6 @@
     "type": "VentilationOpening",
     "fraction_area_operable": 0.5,
     "fraction_height_operable": 1.0,
-    "discharge_coefficient": 0.17,
+    "discharge_coefficient": 0.45,
     "wind_cross_vent": false
 }


### PR DESCRIPTION
If we want to use the discharge coefficient in both simple ventilation and the AFN, it seems we should follow the E+ guide and use a coefficient that corresponds to the height from midpoint of lower opening to the neutral pressure level (deltaHnpl) instead of using the full height of the window.