### PR TITLE
fix(asset): Enforce clean characters for SensorGrid + View display_name

### DIFF
--- a/honeybee_schema/radiance/asset.py
+++ b/honeybee_schema/radiance/asset.py
@@ -1,14 +1,41 @@
 """SensorGrid and Sensor Schema"""
-from pydantic import Field, constr
+from pydantic import Field, constr, validator
 from typing import List
 from enum import Enum
 from ..geometry import Mesh3D
 from .._base import NoExtraBaseModel
 from ._base import IDdRadianceBaseModel
 
+import re
+
 
 class _RadianceAsset(IDdRadianceBaseModel):
     """Hidden base class for all Radiance Assets."""
+
+    display_name: str = Field(
+        default=None,
+        description='Text string for a unique display name, used to set the default '
+        'file name that the radiance asset is written to within a radiance folder. '
+        'Must not contain spaces or special characters.'
+    )
+
+    @validator('display_name')
+    def valid_rad_string_display_name(cls, value):
+        """Check that a string is valid for Radiance.
+
+        This method is modified from the honeybee-core.typing.valid_rad_string method.
+        """
+        if value is not None:
+            try:
+                illegal_match = re.search(r'[^.A-Za-z0-9_-]', value)
+            except TypeError:
+                raise TypeError('display_name must be a text string. Got {}: {}.'.format(
+                    type(value), value))
+            assert illegal_match is None, \
+                'Illegal character "{}" found in display_name'.format(illegal_match.group(0))
+            assert len(value) > 0, \
+                'Input display_name "{}" contains no characters.'.format(value)
+        return value
 
     room_identifier: str = Field(
         None,

--- a/samples/radiance_asset/sensor_grid_detailed.json
+++ b/samples/radiance_asset/sensor_grid_detailed.json
@@ -603,7 +603,7 @@
             ]
         }
     ],
-    "display_name": "Tiny House Sensor Grid",
+    "display_name": "Tiny_House_Sensor_Grid",
     "room_identifier": "Tiny_House_Room",
     "mesh": {
         "type": "Mesh3D",

--- a/scripts/sample_radiance_asset.py
+++ b/scripts/sample_radiance_asset.py
@@ -23,7 +23,7 @@ def sensor_grid_simple(directory):
 def sensor_grid_detailed(directory):
     room1 = Room.from_box('Tiny_House_Room', 5, 10, 3)
     sensor_grid = room1.properties.radiance.generate_sensor_grid(1, 1, 1)
-    sensor_grid.display_name = 'Tiny House Sensor Grid'
+    sensor_grid.display_name = 'Tiny_House_Sensor_Grid'
     dest_file = os.path.join(directory, 'sensor_grid_detailed.json')
     with open(dest_file, 'w') as fp:
         json.dump(sensor_grid.to_dict(), fp, indent=4)


### PR DESCRIPTION
Given that we are now planning to use the display_name to determine the default file name of the .pts and .vf files that are written from these objects, this commit changes the schema to check this property accordingly.