### PR TITLE
fix(lighting): Add baseline_watts_per_area to Lighting class

### DIFF
--- a/honeybee_schema/energy/load.py
+++ b/honeybee_schema/energy/load.py
@@ -129,6 +129,16 @@ class LightingAbridged(IDdEnergyBaseModel):
         'air. Default value is `0`.'
     )
 
+    baseline_watts_per_area: float = Field(
+        11.84029,
+        ge=0,
+        description='The baseline lighting power density in [W/m2] of floor area. '
+        'This baseline is useful to track how much better the installed lights are '
+        'in comparison to a standard like ASHRAE 90.1. If set to None, it will '
+        'default to 11.84029 W/m2, which is that ASHRAE 90.1-2004 baseline for '
+        'an office.'
+    )
+
     @root_validator
     def check_sum_fractions(cls, values):
         "Ensure sum is less than 1."


### PR DESCRIPTION
This new property will provide a user interface for setting the lighting power density in the baseline model creation workflows. This property is really only relevant when users are creating their own ProgramTypes from scratch (as opposed to using the ProgramTypes that come with the honeybee-energy-standards package).

The plan is that the baseline model creation workflows will first look for an equivalent ProgramType in the ASHRAE-2004 standard and use the LPD there. If an equivalent ProgramType in 2004 is not found, this baseline_watts_per_area property will be used instead. The default value for this property is the ASHRAE 2004 baseline for an office, which is the recommended approach when a given program cannot be classified into any of the categories of the ASHRAE standard.

@MingboPeng  and @mostaphaRoudsari .  I just wanted you to be aware of this change here.  I think it's the only change that I will have to make to the current schema to enable baseline model creation workflows.