### PR TITLE
style(requirements): Ensure dependencies are listed only once

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,1 @@
-pydantic==1.7.2
 pydantic-openapi-helper==0.1.6


### PR DESCRIPTION
There's no need for the pydantic dependency here now that it is included within pydantic-openapi-helper==0.1.6