### PR TITLE
ci(docs): fix docs deployment

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -88,7 +88,7 @@ jobs:
       - name: generate docs
         run: |
           python docs.py $(echo $VERSION | sed 's/v//')
-          redoc-cli bundle ./docs/model_inheritance.json -o ./docs/model.html
+          redoc-cli bundle ./docs/model_redoc.json -o ./docs/model.html
         env:
           VERSION: ${{ github.event.client_payload.version }}
 
@@ -98,7 +98,7 @@ jobs:
           # this will use ladybugbot token
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_branch: gh-pages
-          publish_dir: docs/_build/
+          publish_dir: docs/
           force_orphan: true
           keep_files: false
           full_commit_message: 'deploy: update docs'

--- a/.releaserc.json
+++ b/.releaserc.json
@@ -41,6 +41,10 @@
                     {
                         "path": "docs/radiance-asset_mapper.json",
                         "label": "Radiance simulation asset schema mapper"
+                    },
+                    {
+                        "path": "docs/model_json_schema.json",
+                        "label": "Model JSONSchema"
                     }
                 ]
             }

--- a/docs.py
+++ b/docs.py
@@ -107,3 +107,28 @@ for module in modules:
     # add the mapper file
     with open(f'./docs/{_process_name(module["name"])}_mapper.json', 'w') as out_file:
         json.dump(class_mapper(module['module']), out_file, indent=2)
+
+# generate JSONSchema for Honeybee model
+with open('./docs/model_json_schema.json', 'w') as out_file:
+    out_file.write(Model.schema_json(indent=2))
+
+# generate schema for mode with inheritance but without descriminator
+# we will use this file for generating redocly - the full model is too big, and the
+# model with inheritance and discriminators is renders incorrectly
+external_docs = {
+    "description": "OpenAPI Specification with Inheritance",
+    "url": "./model_inheritance.json"
+}
+
+openapi = get_openapi(
+    [Model],
+    title='Honeybee Model Schema',
+    description='Documentation for Honeybee model schema',
+    version=VERSION, info=info,
+    inheritance=True,
+    external_docs=external_docs,
+    add_discriminator=False
+)
+
+with open('./docs/model_redoc.json', 'w') as out_file:
+    json.dump(openapi, out_file, indent=2)


### PR DESCRIPTION
1. fix path to docs folder
2. added JSON Schema object for honeybee model. resolves #182

I also tried to generate a new file without discriminator to fix the docs. It makes it slightly better but doesn't fix the issue. Related #221