### PR TITLE
fix(sensorgrid): Add base_geometry property for SensorGrid

### DIFF
--- a/honeybee_schema/radiance/asset.py
+++ b/honeybee_schema/radiance/asset.py
@@ -2,40 +2,13 @@
 from pydantic import Field, constr, validator
 from typing import List
 from enum import Enum
-from ..geometry import Mesh3D
+from ..geometry import Mesh3D, Face3D
 from .._base import NoExtraBaseModel
 from ._base import IDdRadianceBaseModel
-
-import re
 
 
 class _RadianceAsset(IDdRadianceBaseModel):
     """Hidden base class for all Radiance Assets."""
-
-    display_name: str = Field(
-        default=None,
-        description='Text string for a unique display name, used to set the default '
-        'file name that the radiance asset is written to within a radiance folder. '
-        'Must not contain spaces or special characters.'
-    )
-
-    @validator('display_name')
-    def valid_rad_string_display_name(cls, value):
-        """Check that a string is valid for Radiance.
-
-        This method is modified from the honeybee-core.typing.valid_rad_string method.
-        """
-        if value is not None:
-            try:
-                illegal_match = re.search(r'[^.A-Za-z0-9_-]', value)
-            except TypeError:
-                raise TypeError('display_name must be a text string. Got {}: {}.'.format(
-                    type(value), value))
-            assert illegal_match is None, \
-                'Illegal character "{}" found in display_name'.format(illegal_match.group(0))
-            assert len(value) > 0, \
-                'Input display_name "{}" contains no characters.'.format(value)
-        return value
 
     room_identifier: str = Field(
         None,
@@ -94,6 +67,14 @@ class SensorGrid(_RadianceAsset):
         'used for visualization of the grid. Note that the number of sensors in '
         'the grid must match the number of faces or the number vertices within '
         'the Mesh3D.'
+    )
+
+    base_geometry: List[Face3D] = Field(
+        None,
+        description='An optional array of Face3D used to represent the grid. '
+        'There are no restrictions on how this property relates to the sensors and it '
+        'is provided only to assist with the display of the grid when the number '
+        'of sensors or the mesh is too large to be practically visualized.'
     )
 
 


### PR DESCRIPTION
I am also putting back the older behavior of the SensorGrid and View identifiers. So identifiers are now used to specify the filenames in the model folder (instead of the display_name).

CC: @mostaphaRoudsari , @devngc