### PR TITLE
refactor(updater): refactor updater and removed use of eval

### DIFF
--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,17 +1,21 @@
 """Test the CLI updater commands."""
 import json
-from click.testing import CliRunner
+import pathlib
 
+from click.testing import CliRunner
 from honeybee_schema.cli import update_model
 
 
 def test_update_model():
     input_model = './tests/json/model_old.hbjson'
+    output_model = pathlib.Path('./tests/json/model_new.hbjson')
     runner = CliRunner()
-    result = runner.invoke(update_model, [input_model])
+    result = runner.invoke(
+        update_model, [input_model, '--output-file', output_model.as_posix()]
+    )
     assert result.exit_code == 0
 
-    model_dict = json.loads(result.output)
+    model_dict = json.loads(output_model.read_bytes())
 
     model_ver = tuple(int(v) for v in model_dict['version'].split('.'))
     assert model_ver >= (1, 40, 1)
@@ -19,3 +23,5 @@ def test_update_model():
     updated_hvac = model_dict['properties']['energy']['hvacs'][0]
     assert updated_hvac['vintage'] == 'ASHRAE_2010'
     assert updated_hvac['equipment_type'] == 'PSZAC_DCW_DHW'
+
+    output_model.unlink()


### PR DESCRIPTION
This commit takes advantage of python's inspect and pkgutil and removes `eval`s from the code.

I also added some reporting and updated the test. Click.runner has a bug and mixes the stderr and stdout which was making the test fail after these changes.