### PR TITLE
feat(load): Add an object for EnergyPlus DaylightControl

### DIFF
--- a/honeybee_schema/energy/properties.py
+++ b/honeybee_schema/energy/properties.py
@@ -15,7 +15,7 @@ from .material import EnergyMaterial, EnergyMaterialNoMass, \
 from .programtype import ProgramTypeAbridged, ProgramType
 from .load import PeopleAbridged, LightingAbridged, ElectricEquipmentAbridged, \
     GasEquipmentAbridged, ServiceHotWaterAbridged, InfiltrationAbridged, \
-    VentilationAbridged, SetpointAbridged
+    VentilationAbridged, SetpointAbridged, DaylightingControl
 from .ventcool import VentilationControlAbridged, VentilationOpening, \
     VentilationSimulationControl, AFNCrack
 from .schedule import ScheduleTypeLimit, ScheduleRulesetAbridged, \
@@ -187,6 +187,13 @@ class RoomEnergyPropertiesAbridged(NoExtraBaseModel):
     setpoint: SetpointAbridged = Field(
         default=None,
         description='Setpoint object for the temperature setpoints of the Room.'
+    )
+
+    daylighting_control: DaylightingControl = Field(
+        default=None,
+        description='An optional DaylightingControl object to dictate the dimming '
+        'of lights. If None, the lighting will respond only to the schedule and '
+        'not the daylight conditions within the room.'
     )
 
     window_vent_control: VentilationControlAbridged = Field(

--- a/samples/daylight/daylight_control.json
+++ b/samples/daylight/daylight_control.json
@@ -1,0 +1,9 @@
+{
+    "type": "DaylightingControl",
+    "sensor_position": [5, 5, 0.8],
+    "illuminance_setpoint": 300,
+    "control_fraction": 0.5,
+    "min_power_input": 0.3,
+    "min_light_output": 0.2,
+    "off_at_minimum": true
+}

--- a/tests/test_daylight_control.py
+++ b/tests/test_daylight_control.py
@@ -1,0 +1,11 @@
+from honeybee_schema.energy.load import DaylightingControl
+import os
+
+# target folder where all of the samples live
+root = os.path.dirname(os.path.dirname(__file__))
+target_folder = os.path.join(root, 'samples', 'daylight')
+
+
+def test_daylight_control():
+    file_path = os.path.join(target_folder, 'daylight_control.json')
+    DaylightingControl.parse_file(file_path)


### PR DESCRIPTION
@mingbopeng , This change is purely optional and additive to the schema so there's no need to make any change to the packages using the C# bindings. You can feel free to expose it whenever you get the time and there's no pressure. I only added it as SOM asked to test it during the URBANopt pilot testing period.

The only potentially thing to think through when you eventually expose it is that the daylight controls need a sensor point. So you may need to ask the user for a point that's inside the room volume.