### PR TITLE
ci(deps): Prevent auto-updating dependencies

### DIFF
--- a/.dependabot/config.yml
+++ b/.dependabot/config.yml
@@ -3,6 +3,25 @@ update_configs:
   - package_manager: "python"
     directory: "/"
     update_schedule: "live"
+    ignored_updates:
+      - match:
+          dependency_name: "click"
+      - match:
+          dependency_name: "coveralls"
+      - match:
+          dependency_name: "coverage"
+      - match:
+          dependency_name: "pytest"
+      - match:
+          dependency_name: "pytest-cov"
+      - match:
+          dependency_name: "twine"
+      - match:
+          dependency_name: "setuptools"
+      - match:
+          dependency_name: "wheel"
+      - match:
+          dependency_name: "importlib-metadata"
     automerged_updates:
       - match:
           dependency_type: "all"

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,4 +1,4 @@
-click==8.0.1
+click==7.1.2
 coverage==5.5
 coveralls==2.2.0
 pytest==6.2.4

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ setuptools.setup(
     packages=setuptools.find_packages(exclude=["tests", "scripts", "samples"]),
     install_requires=requirements,
     extras_require={
-        'cli': ['click==8.0.1']
+        'cli': ['click==7.1.2']
     },
     entry_points={
         "console_scripts": ["honeybee-schema = honeybee_schema.cli:main"]


### PR DESCRIPTION
I am also rolling back the click version of the [cli] extra so that we don't end up with version conflicts with the rest of the core libraries.