### PR TITLE
fix(regex): Ensure that regexes are consistent

### DIFF
--- a/honeybee_schema/model.py
+++ b/honeybee_schema/model.py
@@ -292,7 +292,7 @@ class Room(IDdBaseModel):
 
     story: str = Field(
         default=None,
-        regex=r'[A-Za-z0-9_-]',
+        regex=r'[.A-Za-z0-9_-]',
         min_length=1,
         max_length=100,
         description='Text string for the story identifier to which this Room belongs. '

--- a/honeybee_schema/radiance/asset.py
+++ b/honeybee_schema/radiance/asset.py
@@ -12,7 +12,7 @@ class _RadianceAsset(IDdRadianceBaseModel):
 
     room_identifier: str = Field(
         None,
-        regex=r'[A-Za-z0-9_-]',
+        regex=r'[.A-Za-z0-9_-]',
         min_length=1,
         max_length=100,
         description='Optional text string for the Room identifier to which this '


### PR DESCRIPTION
I realized that we should permit the . for all of the relevant regexes.