### PR TITLE
feat(global): Add global construction and modifier sets

### DIFF
--- a/honeybee_schema/energy/constructionset.py
+++ b/honeybee_schema/energy/constructionset.py
@@ -270,7 +270,8 @@ class ConstructionSetAbridged(IDdEnergyBaseModel):
 
     roof_ceiling_set: RoofCeilingConstructionSetAbridged = Field(
         default=None,
-        description='A RoofCeilingConstructionSetAbridged object for this ConstructionSet.'
+        description='A RoofCeilingConstructionSetAbridged object for this '
+        'ConstructionSet.'
     )
 
     aperture_set: ApertureConstructionSetAbridged = Field(

--- a/honeybee_schema/energy/global_constructionset.py
+++ b/honeybee_schema/energy/global_constructionset.py
@@ -1,0 +1,123 @@
+"""Global construction-set for Model."""
+import pathlib
+import json
+
+from typing import List, Union
+from pydantic import constr, Field
+
+from honeybee_standards import energy_default
+
+from .._base import NoExtraBaseModel
+from .constructionset import WallConstructionSetAbridged, FloorConstructionSetAbridged, \
+    RoofCeilingConstructionSetAbridged, ApertureConstructionSetAbridged, \
+    DoorConstructionSetAbridged
+from .construction import OpaqueConstructionAbridged, WindowConstructionAbridged, \
+    ShadeConstruction, AirBoundaryConstructionAbridged
+from .material import EnergyMaterial, EnergyMaterialNoMass, \
+    EnergyWindowMaterialGlazing, EnergyWindowMaterialGas
+
+
+# import constructionset default values from honeybee standards
+_DEFAULTS = json.loads(pathlib.Path(energy_default).read_text())
+_CSET = [
+    ms for ms in _DEFAULTS['construction_sets']
+    if ms['identifier'] == 'Default Generic Construction Set'][0]
+_CONSTRUCTION_NAMES = [
+    'Generic Exterior Wall', 'Generic Interior Wall', 'Generic Underground Wall',
+    'Generic Exposed Floor', 'Generic Interior Floor', 'Generic Ground Slab',
+    'Generic Roof', 'Generic Interior Ceiling', 'Generic Underground Roof',
+    'Generic Double Pane', 'Generic Single Pane', 'Generic Exterior Door',
+    'Generic Interior Door', 'Generic Shade', 'Generic Air Boundary'
+]
+_CONSTRUCTIONS = [
+    OpaqueConstructionAbridged.parse_obj(m)
+    if m['type'] == 'OpaqueConstructionAbridged'
+    else WindowConstructionAbridged.parse_obj(m)
+    if m['type'] == 'WindowConstructionAbridged'
+    else ShadeConstruction.parse_obj(m)
+    if m['type'] == 'ShadeConstruction'
+    else AirBoundaryConstructionAbridged.parse_obj(m)
+    for m in _DEFAULTS['constructions'] if m['identifier'] in _CONSTRUCTION_NAMES
+]
+_MATERIAL_NAMES = [
+    'Generic 25mm Wood', 'Generic Clear Glass', 'Generic LW Concrete',
+    'Generic Ceiling Air Gap', 'Generic Acoustic Tile', 'Generic Gypsum Board',
+    'Generic Wall Air Gap', 'Generic Painted Metal', 'Generic 50mm Insulation',
+    'Generic Roof Membrane', 'Generic Brick', 'Generic HW Concrete',
+    'Generic Low-e Glass', 'Generic Window Air Gap', 'Generic 25mm Insulation'
+]
+_MATERIALS = [
+    EnergyMaterial.parse_obj(m)
+    if m['type'] == 'EnergyMaterial'
+    else EnergyMaterialNoMass.parse_obj(m)
+    if m['type'] == 'EnergyMaterialNoMass'
+    else EnergyWindowMaterialGlazing.parse_obj(m)
+    if m['type'] == 'EnergyWindowMaterialGlazing'
+    else EnergyWindowMaterialGas.parse_obj(m)
+    for m in _DEFAULTS['materials'] if m['identifier'] in _MATERIAL_NAMES
+]
+
+
+class GlobalConstructionSet(NoExtraBaseModel):
+
+    type: constr(regex='^GlobalConstructionSet$') = 'GlobalConstructionSet'
+
+    materials: List[Union[
+        EnergyMaterial, EnergyMaterialNoMass,
+        EnergyWindowMaterialGlazing, EnergyWindowMaterialGas
+    ]] = Field(
+        default=_MATERIALS,
+        description='Global Honeybee Energy materials.',
+        readOnly=True
+    )
+
+    constructions: List[Union[
+        OpaqueConstructionAbridged, WindowConstructionAbridged,
+        ShadeConstruction, AirBoundaryConstructionAbridged
+    ]] = Field(
+        default=_CONSTRUCTIONS,
+        description='Global Honeybee Energy constructions.',
+        readOnly=True
+    )
+
+    wall_set: WallConstructionSetAbridged = Field(
+        default=WallConstructionSetAbridged.parse_obj(_CSET['wall_set']),
+        description='Global Honeybee WallConstructionSet.',
+        readOnly=True
+    )
+
+    floor_set: FloorConstructionSetAbridged = Field(
+        default=FloorConstructionSetAbridged.parse_obj(_CSET['floor_set']),
+        description='Global Honeybee FloorConstructionSet.',
+        readOnly=True
+    )
+
+    roof_ceiling_set: RoofCeilingConstructionSetAbridged = Field(
+        default=RoofCeilingConstructionSetAbridged.parse_obj(_CSET['roof_ceiling_set']),
+        description='Global Honeybee RoofCeilingConstructionSet.',
+        readOnly=True
+    )
+
+    aperture_set: ApertureConstructionSetAbridged = Field(
+        default=ApertureConstructionSetAbridged.parse_obj(_CSET['aperture_set']),
+        description='Global Honeybee ApertureConstructionSet.',
+        readOnly=True
+    )
+
+    door_set: DoorConstructionSetAbridged = Field(
+        default=DoorConstructionSetAbridged.parse_obj(_CSET['door_set']),
+        description='Global Honeybee DoorConstructionSet.',
+        readOnly=True
+    )
+
+    shade_construction: str = Field(
+        default=_CSET['shade_construction'],
+        description='Global Honeybee Construction for Shades.',
+        readOnly=True
+    )
+
+    air_boundary_construction: str = Field(
+        default=_CSET['air_boundary_construction'],
+        description='Global Honeybee Construction for AirBoundary Faces.',
+        readOnly=True
+    )

--- a/honeybee_schema/energy/properties.py
+++ b/honeybee_schema/energy/properties.py
@@ -4,6 +4,7 @@ from typing import List, Union
 
 from .._base import NoExtraBaseModel
 from .constructionset import ConstructionSetAbridged, ConstructionSet
+from .global_constructionset import GlobalConstructionSet
 from .construction import OpaqueConstructionAbridged, WindowConstructionAbridged, \
     ShadeConstruction, AirBoundaryConstructionAbridged, OpaqueConstruction, \
     WindowConstruction, AirBoundaryConstruction, WindowConstructionShadeAbridged, \
@@ -219,6 +220,12 @@ class ModelEnergyProperties(NoExtraBaseModel):
 
     type: constr(regex='^ModelEnergyProperties$') = \
         'ModelEnergyProperties'
+
+    global_construction_set: GlobalConstructionSet = Field(
+        default=GlobalConstructionSet(),
+        description='Global Energy construction set.',
+        readOnly=True
+    )
 
     construction_sets: List[Union[ConstructionSetAbridged, ConstructionSet]] = Field(
         default=None,

--- a/honeybee_schema/radiance/global_modifierset.py
+++ b/honeybee_schema/radiance/global_modifierset.py
@@ -1,0 +1,84 @@
+"""Global modifier-set for Model."""
+import pathlib
+import json
+
+from typing import List, Union
+from pydantic import constr, Field
+
+from honeybee_standards import radiance_default
+
+from .._base import NoExtraBaseModel
+from .modifierset import WallModifierSetAbridged, FloorModifierSetAbridged, \
+    RoofCeilingModifierSetAbridged, ApertureModifierSetAbridged, \
+    DoorModifierSetAbridged, ShadeModifierSetAbridged
+from .modifier import Plastic, Glass
+
+
+# import modifierset default values from honeybee standards
+_DEFAULTS = json.loads(pathlib.Path(radiance_default).read_text())
+_MOD_SET = [
+    ms for ms in _DEFAULTS['modifier_sets']
+    if ms['identifier'] == 'Generic_Interior_Visible_Modifier_Set'][0]
+_MODIFIER_NAMES = [
+    'generic_wall_0.50', 'generic_floor_0.20', 'generic_ceiling_0.80',
+    'generic_interior_window_vis_0.88', 'generic_exterior_window_vis_0.64',
+    'generic_opaque_door_0.50', 'generic_interior_shade_0.50',
+    'generic_exterior_shade_0.35', 'air_boundary'
+]
+_MODIFIERS = [
+    Plastic.parse_obj(m) if m['type'] == 'Plastic' else Glass.parse_obj(m)
+    for m in _DEFAULTS['modifiers'] if m['identifier'] in _MODIFIER_NAMES
+]
+
+
+class GlobalModifierSet(NoExtraBaseModel):
+
+    type: constr(regex='^GlobalModifierSet$') = 'GlobalModifierSet'
+
+    modifiers: List[Union[Plastic, Glass]] = Field(
+        default=_MODIFIERS,
+        description='Global Honeybee Radiance modifiers.',
+        readOnly=True
+    )
+
+    wall_set: WallModifierSetAbridged = Field(
+        default=WallModifierSetAbridged.parse_obj(_MOD_SET['wall_set']),
+        description='Global Honeybee WallModifierSet.',
+        readOnly=True
+    )
+
+    floor_set: FloorModifierSetAbridged = Field(
+        default=FloorModifierSetAbridged.parse_obj(_MOD_SET['floor_set']),
+        description='Global Honeybee FloorModifierSet.',
+        readOnly=True
+    )
+
+    roof_ceiling_set: RoofCeilingModifierSetAbridged = Field(
+        default=RoofCeilingModifierSetAbridged.parse_obj(_MOD_SET['roof_ceiling_set']),
+        description='Global Honeybee RoofCeilingModifierSet.',
+        readOnly=True
+    )
+
+    aperture_set: ApertureModifierSetAbridged = Field(
+        default=ApertureModifierSetAbridged.parse_obj(_MOD_SET['aperture_set']),
+        description='Global Honeybee ApertureModifierSet.',
+        readOnly=True
+    )
+
+    door_set: DoorModifierSetAbridged = Field(
+        default=DoorModifierSetAbridged.parse_obj(_MOD_SET['door_set']),
+        description='Global Honeybee DoorModifierSet.',
+        readOnly=True
+    )
+
+    shade_set: ShadeModifierSetAbridged = Field(
+        default=ShadeModifierSetAbridged.parse_obj(_MOD_SET['shade_set']),
+        description='Global Honeybee ShadeModifierSet.',
+        readOnly=True
+    )
+
+    air_boundary_modifier: str = Field(
+        default=_MOD_SET['air_boundary_modifier'],
+        description='Global Honeybee Modifier for AirBoundary Faces.',
+        readOnly=True
+    )

--- a/honeybee_schema/radiance/properties.py
+++ b/honeybee_schema/radiance/properties.py
@@ -4,6 +4,7 @@ from typing import List, Union
 
 from .modifier import _REFERENCE_UNION_MODIFIERS
 from .modifierset import ModifierSet, ModifierSetAbridged
+from .global_modifierset import GlobalModifierSet
 from .asset import SensorGrid, View
 from .._base import NoExtraBaseModel
 
@@ -111,6 +112,12 @@ class ModelRadianceProperties(NoExtraBaseModel):
     """Radiance Properties for Honeybee Model."""
 
     type: constr(regex='^ModelRadianceProperties$') = 'ModelRadianceProperties'
+
+    global_modifier_set: GlobalModifierSet = Field(
+        default=GlobalModifierSet(),
+        description='Global Radiance modifier set.',
+        readOnly=True
+    )
 
     modifiers: List[_REFERENCE_UNION_MODIFIERS] = Field(
         default=None,

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 pydantic-openapi-helper==0.2.7
+honeybee-standards==2.0.3


### PR DESCRIPTION
Instead of having the "source of truth" for default constructions and modifiers living in an external JSON file in `honeybee_standards`, this commit adds this "source of truth" into honeybee-schema and effectively has it recorded/copied each HBJSON Model.

This way, when other developers receive a HBJSON model, they won't need to have a copy of `honeybee_standards` but can instead just read the `global_modifier_set` and `global_construction_set` properties from the Model JSON itself. These global sets are read-only and will effectively be static for a given version of honeybee-schema.