### PR TITLE
fix(global_modifierset): Ensure air boundaries use invisible trans

### DIFF
--- a/honeybee_schema/radiance/global_modifierset.py
+++ b/honeybee_schema/radiance/global_modifierset.py
@@ -11,7 +11,7 @@ from .._base import NoExtraBaseModel
 from .modifierset import WallModifierSetAbridged, FloorModifierSetAbridged, \
     RoofCeilingModifierSetAbridged, ApertureModifierSetAbridged, \
     DoorModifierSetAbridged, ShadeModifierSetAbridged
-from .modifier import Plastic, Glass
+from .modifier import Plastic, Glass, Trans
 
 
 # import modifierset default values from honeybee standards
@@ -26,7 +26,9 @@ _MODIFIER_NAMES = [
     'generic_exterior_shade_0.35', 'air_boundary'
 ]
 _MODIFIERS = [
-    Plastic.parse_obj(m) if m['type'] == 'Plastic' else Glass.parse_obj(m)
+    Plastic.parse_obj(m) if m['type'] == 'Plastic'
+    else Glass.parse_obj(m) if m['type'] == 'Glass'
+    else Trans.parse_obj(m)
     for m in _DEFAULTS['modifiers'] if m['identifier'] in _MODIFIER_NAMES
 ]
 

--- a/honeybee_schema/radiance/modifier.py
+++ b/honeybee_schema/radiance/modifier.py
@@ -1,6 +1,6 @@
 """Modifier Schema"""
 from __future__ import annotations
-from pydantic import Field, BaseModel, constr, validator, root_validator
+from pydantic import Field, BaseModel, constr, validator
 from typing import List, Union, Optional
 from ._base import IDdRadianceBaseModel
 
@@ -155,21 +155,6 @@ class Trans(Plastic):
         le=1,
         description='The fraction of transmitted light that is not diffusely scattered.'
     )
-
-    @root_validator
-    def check_sum_fractions(cls, values):
-        """Ensure sum is less than 1."""
-        trans_diff = values.get('transmitted_diff')
-        trans_spec = values.get('transmitted_spec')
-        r_refl = values.get('r_reflectance')
-        g_refl = values.get('g_reflectance')
-        b_refl = values.get('b_reflectance')
-        identifier = values.get('identifier')
-        summed = trans_diff + trans_spec + (r_refl + g_refl + b_refl) / 3.0
-        assert summed <= 1, 'The sum of the transmitted and reflected ' \
-            'fractions cannot be greater than 1, but is {} for modifier {}.'.format(
-                summed, identifier)
-        return values
 
 
 class Glass(ModifierBase):

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 pydantic-openapi-helper==0.2.7
-honeybee-standards==2.0.3
+honeybee-standards==2.0.4

--- a/tests/test_modifier.py
+++ b/tests/test_modifier.py
@@ -105,6 +105,5 @@ def test_trans_tree_foliage_wrong():
     trans_modifier_test = copy(trans_modifier)
     trans_modifier_test["transmitted_diff"] = 0.6
     trans_modifier_test["transmitted_spec"] = 0.6
-    with pytest.raises(ValidationError):
-        Trans.parse_obj(trans_modifier_test)
+    Trans.parse_obj(trans_modifier_test)
 


### PR DESCRIPTION
This is linked to this issue here:

https://discourse.ladybug.tools/t/airboundary-not-considered-fully-transparent-by-radiance/15191/