### PR TITLE
fix(energy): Add user_data key to all energy resource objects

### DIFF
--- a/honeybee_schema/energy/_base.py
+++ b/honeybee_schema/energy/_base.py
@@ -5,7 +5,7 @@ import datetime
 from .._base import NoExtraBaseModel
 
 
-class IDdEnergyBaseModel(NoExtraBaseModel):
+class EnergyBaseModel(NoExtraBaseModel):
     """Base class for all objects requiring a valid EnergyPlus identifier."""
 
     identifier: str = Field(
@@ -23,6 +23,18 @@ class IDdEnergyBaseModel(NoExtraBaseModel):
     display_name: str = Field(
         default=None,
         description='Display name of the object with no character restrictions.'
+    )
+
+
+class IDdEnergyBaseModel(EnergyBaseModel):
+    """Base class for all objects requiring an EnergyPlus identifier and user_data."""
+
+    user_data: dict = Field(
+        default=None,
+        description='Optional dictionary of user data associated with the object.'
+        'All keys and values of this dictionary should be of a standard data '
+        'type to ensure correct serialization of the object (eg. str, float, '
+        'int, list).'
     )
 
 

--- a/honeybee_schema/energy/schedule.py
+++ b/honeybee_schema/energy/schedule.py
@@ -4,7 +4,7 @@ from typing import List, Union
 from enum import Enum
 import datetime
 
-from ._base import IDdEnergyBaseModel, DatedBaseModel
+from ._base import IDdEnergyBaseModel, DatedBaseModel, EnergyBaseModel
 from ..altnumber import NoLimit
 
 
@@ -31,7 +31,7 @@ class ScheduleUnitType (str, Enum):
     mode = 'Mode'
 
 
-class ScheduleTypeLimit(IDdEnergyBaseModel):
+class ScheduleTypeLimit(EnergyBaseModel):
     """Specifies the data types and limits for values contained in schedules."""
 
     type: constr(regex='^ScheduleTypeLimit$') = 'ScheduleTypeLimit'
@@ -51,7 +51,7 @@ class ScheduleTypeLimit(IDdEnergyBaseModel):
     unit_type: ScheduleUnitType = ScheduleUnitType.dimensionless
 
 
-class ScheduleDay(IDdEnergyBaseModel):
+class ScheduleDay(EnergyBaseModel):
     """Used to describe the daily schedule for a single simulation day."""
 
     type: constr(regex='^ScheduleDay$') = 'ScheduleDay'

--- a/honeybee_schema/radiance/modifier.py
+++ b/honeybee_schema/radiance/modifier.py
@@ -197,8 +197,9 @@ class Glass(ModifierBase):
 
     refraction_index: Optional[float] = Field(
         default=1.52,
-        ge=0,
-        description='A value between 0 and 1 for the index of refraction.'
+        gt=1,
+        description='A value greater than 1 for the index of refraction. Typical '
+        'values are 1.52 for float glass and 1.4 for ETFE.'
     )
 
 


### PR DESCRIPTION
This brings the schema to be in line with the latest honeybee-energy library, which supports user_data for things like constructions.

I am also changing the Glass.refraction_index to be greater than 1 since it seems that values less than 1 will cause Radiance to get stuck in an endless loop.