### PR TITLE
fix(simulation): Remove non-functional properties of energy sim param

### DIFF
--- a/honeybee_schema/energy/simulation.py
+++ b/honeybee_schema/energy/simulation.py
@@ -23,18 +23,6 @@ class SimulationOutput(NoExtraBaseModel):
 
     reporting_frequency: ReportingFrequency = ReportingFrequency.hourly
 
-    include_sqlite: bool = Field(
-        default=True,
-        description='Boolean to note whether a SQLite report should be requested '
-        'from the simulation.'
-    )
-
-    include_html: bool = Field(
-        default=True,
-        description='Boolean to note whether an HTML report should be requested '
-        'from the simulation.'
-    )
-
     outputs: List[str] = Field(
         default=None,
         description='A list of EnergyPlus output names as strings, which are requested '

--- a/samples/simulation_parameter/simulation_par_detailed.json
+++ b/samples/simulation_parameter/simulation_par_detailed.json
@@ -3,8 +3,6 @@
     "output": {
         "type": "SimulationOutput",
         "reporting_frequency": "Daily",
-        "include_sqlite": true,
-        "include_html": true,
         "outputs": [
             "Zone Electric Equipment Electric Energy",
             "Zone Gas Equipment Gas Energy",

--- a/samples/simulation_parameter/simulation_par_simple.json
+++ b/samples/simulation_parameter/simulation_par_simple.json
@@ -3,8 +3,6 @@
     "output": {
         "type": "SimulationOutput",
         "reporting_frequency": "Hourly",
-        "include_sqlite": true,
-        "include_html": true,
         "summary_reports": [
             "AllSummary"
         ]


### PR DESCRIPTION
@mingbopeng , I originally put these properties into the simulation parameters since I was not sure if they would be exposed on the OpenStudio SDK at some point. Now that I have confirmation that NREL does not intend to expose them since they could could break reporting measures, I think they should be removed from honeybee-schema. I'm requesting your review here before I merge so that you get a chance to fix things on the Rhino plugin before these properties are gone. Please feel free to merge this PR as soon as you are ready for he change, @mingbopeng .