### PR TITLE
fix(deps): Loosen pydantic requirement

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-pydantic-openapi-helper==0.2.9
+pydantic-openapi-helper>=0.2.10
 honeybee-standards==2.0.6


### PR DESCRIPTION
This is creating all kinds of headaches with the other repos, especially those like the VTK ones that only use pydantic and not the openapi helper.